### PR TITLE
Monster stats

### DIFF
--- a/src/components/monster/Monster.tsx
+++ b/src/components/monster/Monster.tsx
@@ -50,6 +50,21 @@ class Monster extends Component<{ classes: any }, MonsterProps> {
     name: 'Harold the Destroyer',
     alignment: 'Lawful Good',
     size: 'Large',
+    stats: {
+      armourClass: 23,
+      hitPoints: 543,
+      hitDie: '12d20',
+      speed: '50 land',
+      str: 20,
+      dex: 20,
+      con: 20,
+      int: 20,
+      wis: 20,
+      chr: 20,
+      proficiencyBonus: 12,
+      proficiencies: ['something', 'anothaone'],
+      savingThrows: ['str', 'dex', 'con', 'int', 'wis', 'chr'],
+    },
   };
 
   /**

--- a/src/components/monster/Monster.tsx
+++ b/src/components/monster/Monster.tsx
@@ -43,6 +43,18 @@ export interface MonsterProps {
   name: string;
   size: string;
   alignment: string;
+  armourClass: string;
+  hitPoints: string;
+  hitDie: string;
+  speed: string;
+  str: string;
+  dex: string;
+  con: string;
+  int: string;
+  wis: string;
+  chr: string;
+  profBonus: string;
+  proficiencies: Array<string>;
   savingThrows: Array<string>;
 }
 
@@ -55,8 +67,8 @@ class Monster extends Component<{ classes: any }, MonsterProps> {
    */
   public state = {
     name: 'Harold the Destroyer',
-    alignment: 'Lawful Good',
     size: 'Large',
+    alignment: 'Lawful Good',
     armourClass: '23',
     hitPoints: '543',
     hitDie: '12d20',
@@ -68,7 +80,7 @@ class Monster extends Component<{ classes: any }, MonsterProps> {
     wis: '20',
     chr: '20',
     profBonus: '12',
-    proficiencies: ['ins', 'pfm'],
+    proficiencies: new Array<string>(),
     savingThrows: new Array<string>(),
   };
 

--- a/src/components/monster/Monster.tsx
+++ b/src/components/monster/Monster.tsx
@@ -43,6 +43,7 @@ export interface MonsterProps {
   name: string;
   size: string;
   alignment: string;
+  savingThrows: Array<string>;
 }
 
 class Monster extends Component<{ classes: any }, MonsterProps> {
@@ -68,7 +69,7 @@ class Monster extends Component<{ classes: any }, MonsterProps> {
     chr: '20',
     profBonus: '12',
     proficiencies: ['ins', 'pfm'],
-    savingThrows: ['str', 'dex', 'con', 'int', 'wis', 'chr'],
+    savingThrows: new Array<string>(),
   };
 
   /**

--- a/src/components/monster/Monster.tsx
+++ b/src/components/monster/Monster.tsx
@@ -46,37 +46,44 @@ export interface MonsterProps {
 }
 
 class Monster extends Component<{ classes: any }, MonsterProps> {
+  /**
+   * Unfortunately a few of these fields which should be number can't
+   * due to the material UI's number input fields not working how I would
+   * like, so I made a work around making it so only numbers can be put
+   * in normal textfields which forces the types to have to be strings
+   */
   public state = {
     name: 'Harold the Destroyer',
     alignment: 'Lawful Good',
     size: 'Large',
-    stats: {
-      armourClass: 23,
-      hitPoints: 543,
-      hitDie: '12d20',
-      speed: '50 land',
-      str: 20,
-      dex: 20,
-      con: 20,
-      int: 20,
-      wis: 20,
-      chr: 20,
-      proficiencyBonus: 12,
-      proficiencies: ['something', 'anothaone'],
-      savingThrows: ['str', 'dex', 'con', 'int', 'wis', 'chr'],
-    },
+    armourClass: '23',
+    hitPoints: '543',
+    hitDie: '12d20',
+    speed: '50 land',
+    str: '20',
+    dex: '20',
+    con: '20',
+    int: '20',
+    wis: '20',
+    chr: '20',
+    profBonus: '12',
+    proficiencies: ['ins', 'pfm'],
+    savingThrows: ['str', 'dex', 'con', 'int', 'wis', 'chr'],
   };
 
   /**
-   * Updates the state of the monster on a change
+   * Updates the state of the monster on a change.
    * @param event The material UI event
    */
-  private handleChange = (event: { target: { name: any; value: any } }) => {
+  private handleChange = (event: {
+    target: { name: any; value: any; valueAsNumber: boolean };
+  }) => {
     // Update the passed in key with it's value pair
     const newState = { [event.target.name]: event.target.value } as Pick<
       MonsterProps,
       keyof MonsterProps
     >;
+
     this.setState(newState);
   };
 
@@ -110,7 +117,22 @@ class Monster extends Component<{ classes: any }, MonsterProps> {
             </Typography>
           </ExpansionPanelSummary>
           <ExpansionPanelDetails>
-            <MonsterStats />
+            <MonsterStats
+              handleChange={this.handleChange}
+              armourClass={this.state.armourClass}
+              hitPoints={this.state.hitPoints}
+              hitDie={this.state.hitDie}
+              speed={this.state.speed}
+              str={this.state.str}
+              dex={this.state.dex}
+              con={this.state.con}
+              int={this.state.int}
+              wis={this.state.wis}
+              chr={this.state.chr}
+              profBonus={this.state.profBonus}
+              proficiencies={this.state.proficiencies}
+              savingThrows={this.state.savingThrows}
+            />
           </ExpansionPanelDetails>
         </ExpansionPanel>
 

--- a/src/components/monster/monster-stats/MonsterStats.tsx
+++ b/src/components/monster/monster-stats/MonsterStats.tsx
@@ -1,9 +1,24 @@
 /**
  * MonsterStats.tsx
  * Handles the stats for the monster.
+ * Unfortunately a few of these fields which should be number can't
+ * due to the material UI's number input fields not working how I would
+ * like, so I made a work around making it so only numbers can be put
+ * in normal textfields which forces the types to have to be strings
  */
 import React from 'react';
-import { TextField, Box, Theme, withStyles } from '@material-ui/core';
+import {
+  TextField,
+  Box,
+  Theme,
+  withStyles,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Checkbox,
+  ListItemText,
+} from '@material-ui/core';
 import PropTypes from 'prop-types';
 
 /** Setup the styling for these inputs */
@@ -18,91 +33,259 @@ const useStyles = (theme: Theme) => ({
 });
 
 export interface MonsterStatProps {
+  armourClass: string;
+  hitPoints: string;
+  str: string;
+  dex: string;
+  con: string;
+  int: string;
+  wis: string;
+  chr: string;
+  profBonus: string;
+  hitDie: string;
+  speed: string;
+  proficiencies: Array<string>;
+  savingThrows: Array<string>;
+  handleChange: any;
   classes: any;
 }
 
 class MonsterStats extends React.Component<MonsterStatProps> {
   static propTypes: { [key in keyof MonsterStatProps]: any } = {
+    armourClass: PropTypes.string.isRequired,
+    hitPoints: PropTypes.string.isRequired,
+    str: PropTypes.string.isRequired,
+    dex: PropTypes.string.isRequired,
+    con: PropTypes.string.isRequired,
+    int: PropTypes.string.isRequired,
+    wis: PropTypes.string.isRequired,
+    chr: PropTypes.string.isRequired,
+    profBonus: PropTypes.string.isRequired,
+    hitDie: PropTypes.string.isRequired,
+    speed: PropTypes.string.isRequired,
+    proficiencies: PropTypes.array.isRequired,
+    savingThrows: PropTypes.array.isRequired,
+    handleChange: PropTypes.func.isRequired,
     classes: PropTypes.object,
   };
 
+  /**
+   * Get a list of proficiencies available to 5e
+   */
+  private getProficiencies(): Array<{ value: string; name: string }> {
+    return [
+      { value: 'ath', name: 'Athletics' },
+      { value: 'acr', name: 'Acrobatics' },
+      { value: 'soh', name: 'Sleight of Hand' },
+      { value: 'sth', name: 'Stealth' },
+      { value: 'arc', name: 'Arcana' },
+      { value: 'hst', name: 'History' },
+      { value: 'inv', name: 'Investigation' },
+      { value: 'nat', name: 'Nature' },
+      { value: 'rel', name: 'Religion' },
+      { value: 'anh', name: 'Animal Handling' },
+      { value: 'ins', name: 'Insight' },
+      { value: 'med', name: 'Medicine' },
+      { value: 'per', name: 'Perception' },
+      { value: 'svl', name: 'Survival' },
+      { value: 'dec', name: 'Deception' },
+      { value: 'imd', name: 'Intimidation' },
+      { value: 'pfm', name: 'Performance' },
+      { value: 'psn', name: 'Persuasion' },
+    ];
+  }
+
+  /**
+   * Get a list of saving throws available to 5e
+   */
+  private getSavingThrows(): Array<{ value: string; name: string }> {
+    return [
+      { value: 'str', name: 'Strength' },
+      { value: 'dex', name: 'Dexterity' },
+      { value: 'con', name: 'Constitution' },
+      { value: 'int', name: 'Wisdom' },
+      { value: 'chr', name: 'Charisma' },
+    ];
+  }
+
+  /**
+   * Takes an input event and checks to see if it was an integer input
+   * before trying to update the state
+   * @param event The event passed in from material UI onChange
+   */
+  private handleIntChange = (event: { target: { name: any; value: any } }) => {
+    // If it's null or a number value we will let it update the state in the parent
+    if (event.target.value == null || /^-?[0-9]*$/.test(event.target.value)) {
+      // event.target.value = Number(event.target.value);
+      event.target.value = parseInt(event.target.value);
+      this.props.handleChange(event);
+    }
+  };
+
   render() {
-    const { classes } = this.props;
+    const {
+      classes,
+      armourClass,
+      hitPoints,
+      str,
+      dex,
+      con,
+      int,
+      wis,
+      chr,
+      profBonus,
+      proficiencies,
+      savingThrows,
+      hitDie,
+      speed,
+    } = this.props;
+
+    // Populate the saving throws and the proficiencies dropdowns
+    const availableProfs: Array<{
+      value: string;
+      name: string;
+    }> = this.getProficiencies();
+    const availableSavingThrows: Array<{
+      value: string;
+      name: string;
+    }> = this.getSavingThrows();
 
     return (
       <div className={classes.descriptionRoot}>
         <Box display="flex" flexDirection="row">
           <TextField
             className={classes.inputField}
-            id="standard-basic"
+            value={armourClass}
+            name="armourClass"
             label="Armour Class"
+            onChange={this.handleIntChange}
           />
           <TextField
             className={classes.inputField}
-            id="standard-basic"
             label="Hit Points"
+            value={hitPoints}
+            name="hitPoints"
+            onChange={this.handleIntChange}
           />
           <TextField
             className={classes.inputField}
-            id="standard-basic"
             label="Hit Die"
+            value={hitDie}
+            name="hitDie"
+            onChange={this.props.handleChange}
           />
           <TextField
             className={classes.inputField}
-            id="standard-basic"
             label="Speed"
+            value={speed}
+            name="speed"
+            onChange={this.props.handleChange}
           />
         </Box>
 
         <Box display="flex" flexDirection="row">
           <TextField
             className={classes.inputField}
-            id="standard-basic"
             label="Strength"
+            value={str}
+            name="str"
+            onChange={this.handleIntChange}
           />
           <TextField
             className={classes.inputField}
-            id="standard-basic"
-            label="Dex"
+            label="Dexerity"
+            value={dex}
+            name="dex"
+            onChange={this.handleIntChange}
           />
           <TextField
             className={classes.inputField}
-            id="standard-basic"
-            label="Con"
+            label="Constitution"
+            value={con}
+            name="con"
+            onChange={this.handleIntChange}
           />
           <TextField
             className={classes.inputField}
-            id="standard-basic"
-            label="Int"
+            label="Intelligence"
+            value={int}
+            name="int"
+            onChange={this.handleIntChange}
           />
           <TextField
             className={classes.inputField}
-            id="standard-basic"
-            label="Wis"
+            label="Wisdom"
+            value={wis}
+            name="wis"
+            onChange={this.handleIntChange}
           />
           <TextField
             className={classes.inputField}
-            id="standard-basic"
             label="Charisma"
+            value={chr}
+            name="chr"
+            onChange={this.handleIntChange}
           />
         </Box>
 
         <Box display="flex" flexDirection="row">
           <TextField
             className={classes.inputField}
-            id="standard-basic"
             label="Proficiency Bonus"
+            value={profBonus}
+            name="profBonus"
+            onChange={this.handleIntChange}
           />
-          <TextField
-            className={classes.inputField}
-            id="standard-basic"
-            label="Skill Proficiencies"
-          />
-          <TextField
-            className={classes.inputField}
-            id="standard-basic"
-            label="Saving Throws"
-          />
+          <FormControl className={classes.inputField}>
+            <InputLabel id="skillProf-label">Skill Proficiencies</InputLabel>
+            <Select
+              name="proficiencies"
+              multiple
+              labelId="skillProf-label"
+              id="skillProf-select"
+              value={proficiencies}
+              onChange={this.props.handleChange}
+            >
+              <MenuItem value="">
+                <em>None</em>
+              </MenuItem>
+              <MenuItem value="">
+                <em>None</em>
+              </MenuItem>
+              {availableProfs.map((prof: { value: string; name: string }) => (
+                <MenuItem key={prof.value} value={prof.value}>
+                  <Checkbox checked={proficiencies.indexOf(prof.name) > -1} />
+                  <ListItemText primary={prof.name} />
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <FormControl className={classes.inputField}>
+            <InputLabel id="savingThrows-label">Saving Throws</InputLabel>
+            <Select
+              name="savingThrows"
+              multiple
+              labelId="savingThrows-label"
+              id="savingThrows-select"
+              value={savingThrows}
+              renderValue={() => savingThrows.join(', ')}
+              onChange={this.props.handleChange}
+            >
+              <MenuItem value="">
+                <em>None</em>
+              </MenuItem>
+              {availableSavingThrows.map(
+                (savingThrow: { value: string; name: string }) => (
+                  <MenuItem key={savingThrow.value} value={savingThrow.value}>
+                    <Checkbox
+                      checked={savingThrows.indexOf(savingThrow.name) > -1}
+                    />
+                    <ListItemText primary={savingThrow.name} />
+                  </MenuItem>
+                )
+              )}
+            </Select>
+          </FormControl>
         </Box>
       </div>
     );

--- a/src/components/monster/monster-stats/MonsterStats.tsx
+++ b/src/components/monster/monster-stats/MonsterStats.tsx
@@ -16,8 +16,6 @@ import {
   InputLabel,
   Select,
   MenuItem,
-  Checkbox,
-  ListItemText,
 } from '@material-ui/core';
 import PropTypes from 'prop-types';
 
@@ -32,6 +30,9 @@ const useStyles = (theme: Theme) => ({
   },
 });
 
+/**
+ * Setup the props for monster stats
+ */
 export interface MonsterStatProps {
   armourClass: string;
   hitPoints: string;
@@ -51,6 +52,7 @@ export interface MonsterStatProps {
 }
 
 class MonsterStats extends React.Component<MonsterStatProps> {
+  // Setup the prop types
   static propTypes: { [key in keyof MonsterStatProps]: any } = {
     armourClass: PropTypes.string.isRequired,
     hitPoints: PropTypes.string.isRequired,
@@ -154,6 +156,7 @@ class MonsterStats extends React.Component<MonsterStatProps> {
       <div className={classes.descriptionRoot}>
         <Box display="flex" flexDirection="row">
           <TextField
+            style={{ width: '20%' }}
             className={classes.inputField}
             value={armourClass}
             name="armourClass"
@@ -161,6 +164,7 @@ class MonsterStats extends React.Component<MonsterStatProps> {
             onChange={this.handleIntChange}
           />
           <TextField
+            style={{ width: '20%' }}
             className={classes.inputField}
             label="Hit Points"
             value={hitPoints}
@@ -168,6 +172,7 @@ class MonsterStats extends React.Component<MonsterStatProps> {
             onChange={this.handleIntChange}
           />
           <TextField
+            style={{ width: '20%' }}
             className={classes.inputField}
             label="Hit Die"
             value={hitDie}
@@ -175,6 +180,7 @@ class MonsterStats extends React.Component<MonsterStatProps> {
             onChange={this.props.handleChange}
           />
           <TextField
+            style={{ width: '40%' }}
             className={classes.inputField}
             label="Speed"
             value={speed}
@@ -235,8 +241,9 @@ class MonsterStats extends React.Component<MonsterStatProps> {
             value={profBonus}
             name="profBonus"
             onChange={this.handleIntChange}
+            style={{ width: '20%' }}
           />
-          <FormControl className={classes.inputField}>
+          <FormControl className={classes.inputField} style={{ width: '40%' }}>
             <InputLabel id="skillProf-label">Skill Proficiencies</InputLabel>
             <Select
               name="proficiencies"
@@ -246,41 +253,26 @@ class MonsterStats extends React.Component<MonsterStatProps> {
               value={proficiencies}
               onChange={this.props.handleChange}
             >
-              <MenuItem value="">
-                <em>None</em>
-              </MenuItem>
-              <MenuItem value="">
-                <em>None</em>
-              </MenuItem>
               {availableProfs.map((prof: { value: string; name: string }) => (
                 <MenuItem key={prof.value} value={prof.value}>
-                  <Checkbox checked={proficiencies.indexOf(prof.name) > -1} />
-                  <ListItemText primary={prof.name} />
+                  {prof.name}
                 </MenuItem>
               ))}
             </Select>
           </FormControl>
-          <FormControl className={classes.inputField}>
+          <FormControl className={classes.inputField} style={{ width: '40%' }}>
             <InputLabel id="savingThrows-label">Saving Throws</InputLabel>
             <Select
               name="savingThrows"
               multiple
               labelId="savingThrows-label"
-              id="savingThrows-select"
               value={savingThrows}
-              renderValue={() => savingThrows.join(', ')}
               onChange={this.props.handleChange}
             >
-              <MenuItem value="">
-                <em>None</em>
-              </MenuItem>
               {availableSavingThrows.map(
                 (savingThrow: { value: string; name: string }) => (
                   <MenuItem key={savingThrow.value} value={savingThrow.value}>
-                    <Checkbox
-                      checked={savingThrows.indexOf(savingThrow.name) > -1}
-                    />
-                    <ListItemText primary={savingThrow.name} />
+                    {savingThrow.name}
                   </MenuItem>
                 )
               )}

--- a/src/components/monster/monster-stats/MonsterStats.tsx
+++ b/src/components/monster/monster-stats/MonsterStats.tsx
@@ -2,26 +2,36 @@
  * Handles the monster's stats
  */
 import React from 'react';
-import { TextField } from '@material-ui/core';
+import { TextField, Box } from '@material-ui/core';
 
-export default function MonsterStats() {
-  return (
-    <div>
-      <TextField id="standard-basic" label="Armour Class" />
-      <TextField id="standard-basic" label="Hit Points" />
-      <TextField id="standard-basic" label="Hit Die" />
-      <TextField id="standard-basic" label="Speed" />
+class MonsterStats extends React.Component {
+  render() {
+    return (
+      <div>
+        <Box>
+          <TextField id="standard-basic" label="Armour Class" />
+          <TextField id="standard-basic" label="Hit Points" />
+          <TextField id="standard-basic" label="Hit Die" />
+          <TextField id="standard-basic" label="Speed" />
+        </Box>
 
-      <TextField id="standard-basic" label="Strength" />
-      <TextField id="standard-basic" label="Dex" />
-      <TextField id="standard-basic" label="Con" />
-      <TextField id="standard-basic" label="Int" />
-      <TextField id="standard-basic" label="Wis" />
-      <TextField id="standard-basic" label="Charisma" />
-      <TextField id="standard-basic" label="Proficiency Bonus" />
+        <Box>
+          <TextField id="standard-basic" label="Strength" />
+          <TextField id="standard-basic" label="Dex" />
+          <TextField id="standard-basic" label="Con" />
+          <TextField id="standard-basic" label="Int" />
+          <TextField id="standard-basic" label="Wis" />
+          <TextField id="standard-basic" label="Charisma" />
+          <TextField id="standard-basic" label="Proficiency Bonus" />
+        </Box>
 
-      <TextField id="standard-basic" label="Saving Throws" />
-      <TextField id="standard-basic" label="Skill Proficiencies" />
-    </div>
-  );
+        <Box>
+          <TextField id="standard-basic" label="Saving Throws" />
+          <TextField id="standard-basic" label="Skill Proficiencies" />
+        </Box>
+      </div>
+    );
+  }
 }
+
+export default MonsterStats;

--- a/src/components/monster/monster-stats/MonsterStats.tsx
+++ b/src/components/monster/monster-stats/MonsterStats.tsx
@@ -1,37 +1,112 @@
 /**
- * Handles the monster's stats
+ * MonsterStats.tsx
+ * Handles the stats for the monster.
  */
 import React from 'react';
-import { TextField, Box } from '@material-ui/core';
+import { TextField, Box, Theme, withStyles } from '@material-ui/core';
+import PropTypes from 'prop-types';
 
-class MonsterStats extends React.Component {
+/** Setup the styling for these inputs */
+const useStyles = (theme: Theme) => ({
+  descriptionRoot: {
+    width: '100%',
+  },
+  inputField: {
+    display: 'flex',
+    margin: theme.spacing(1),
+  },
+});
+
+export interface MonsterStatProps {
+  classes: any;
+}
+
+class MonsterStats extends React.Component<MonsterStatProps> {
+  static propTypes: { [key in keyof MonsterStatProps]: any } = {
+    classes: PropTypes.object,
+  };
+
   render() {
+    const { classes } = this.props;
+
     return (
-      <div>
-        <Box>
-          <TextField id="standard-basic" label="Armour Class" />
-          <TextField id="standard-basic" label="Hit Points" />
-          <TextField id="standard-basic" label="Hit Die" />
-          <TextField id="standard-basic" label="Speed" />
+      <div className={classes.descriptionRoot}>
+        <Box display="flex" flexDirection="row">
+          <TextField
+            className={classes.inputField}
+            id="standard-basic"
+            label="Armour Class"
+          />
+          <TextField
+            className={classes.inputField}
+            id="standard-basic"
+            label="Hit Points"
+          />
+          <TextField
+            className={classes.inputField}
+            id="standard-basic"
+            label="Hit Die"
+          />
+          <TextField
+            className={classes.inputField}
+            id="standard-basic"
+            label="Speed"
+          />
         </Box>
 
-        <Box>
-          <TextField id="standard-basic" label="Strength" />
-          <TextField id="standard-basic" label="Dex" />
-          <TextField id="standard-basic" label="Con" />
-          <TextField id="standard-basic" label="Int" />
-          <TextField id="standard-basic" label="Wis" />
-          <TextField id="standard-basic" label="Charisma" />
-          <TextField id="standard-basic" label="Proficiency Bonus" />
+        <Box display="flex" flexDirection="row">
+          <TextField
+            className={classes.inputField}
+            id="standard-basic"
+            label="Strength"
+          />
+          <TextField
+            className={classes.inputField}
+            id="standard-basic"
+            label="Dex"
+          />
+          <TextField
+            className={classes.inputField}
+            id="standard-basic"
+            label="Con"
+          />
+          <TextField
+            className={classes.inputField}
+            id="standard-basic"
+            label="Int"
+          />
+          <TextField
+            className={classes.inputField}
+            id="standard-basic"
+            label="Wis"
+          />
+          <TextField
+            className={classes.inputField}
+            id="standard-basic"
+            label="Charisma"
+          />
         </Box>
 
-        <Box>
-          <TextField id="standard-basic" label="Saving Throws" />
-          <TextField id="standard-basic" label="Skill Proficiencies" />
+        <Box display="flex" flexDirection="row">
+          <TextField
+            className={classes.inputField}
+            id="standard-basic"
+            label="Proficiency Bonus"
+          />
+          <TextField
+            className={classes.inputField}
+            id="standard-basic"
+            label="Skill Proficiencies"
+          />
+          <TextField
+            className={classes.inputField}
+            id="standard-basic"
+            label="Saving Throws"
+          />
         </Box>
       </div>
     );
   }
 }
 
-export default MonsterStats;
+export default withStyles(useStyles, { withTheme: true })(MonsterStats);


### PR DESCRIPTION
**Monster**
- Added monster stat properties to the state. This can be broken down a little cleaner later on.

**Monster Stats**
- Formatted the monster stats fields
- Added list of proficiencies and saving throws
- There is an issue with Material UI Number inputs not working how I'd like. This needs to be updated later.
- Added all the stats as props on the MonsterStats, this can be improved as a singular object in the future to clean up the code