### PR TITLE
Monster Abilities List

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2060,6 +2060,11 @@
         }
       }
     },
+    "@types/uuid": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ=="
+    },
     "@types/webpack": {
       "version": "4.41.17",
       "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.17.tgz",
@@ -11791,6 +11796,13 @@
           "requires": {
             "faye-websocket": "^0.10.0",
             "uuid": "^3.0.1"
+          },
+          "dependencies": {
+            "uuid": {
+              "version": "3.4.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+              "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+            }
           }
         },
         "source-map": {
@@ -11972,6 +11984,13 @@
           "requires": {
             "ansi-colors": "^3.0.0",
             "uuid": "^3.3.2"
+          },
+          "dependencies": {
+            "uuid": {
+              "version": "3.4.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+              "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+            }
           }
         },
         "wrap-ansi": {
@@ -12368,6 +12387,13 @@
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "request-promise-core": {
@@ -13126,6 +13152,14 @@
         "faye-websocket": "^0.10.0",
         "uuid": "^3.4.0",
         "websocket-driver": "0.6.5"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
       }
     },
     "sockjs-client": {
@@ -14284,9 +14318,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
+      "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ=="
     },
     "v8-compile-cache": {
       "version": "2.1.1",
@@ -14664,6 +14698,13 @@
           "requires": {
             "ansi-colors": "^3.0.0",
             "uuid": "^3.3.2"
+          },
+          "dependencies": {
+            "uuid": {
+              "version": "3.4.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+              "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+            }
           }
         }
       }
@@ -14838,6 +14879,14 @@
           "requires": {
             "ansi-colors": "^3.0.0",
             "uuid": "^3.3.2"
+          },
+          "dependencies": {
+            "uuid": {
+              "version": "3.4.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+              "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+              "dev": true
+            }
           }
         },
         "ws": {
@@ -14861,6 +14910,14 @@
         "log-symbols": "^2.1.0",
         "loglevelnext": "^1.0.1",
         "uuid": "^3.1.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
       }
     },
     "webpack-manifest-plugin": {

--- a/package.json
+++ b/package.json
@@ -10,9 +10,11 @@
     "@testing-library/user-event": "^7.2.1",
     "@types/jest": "^26.0.0",
     "@types/node": "^14.0.13",
+    "@types/uuid": "^8.3.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-scripts": "3.4.1"
+    "react-scripts": "3.4.1",
+    "uuid": "^8.3.0"
   },
   "scripts": {
     "start": "webpack-dev-server --open",

--- a/src/components/monster/Monster.tsx
+++ b/src/components/monster/Monster.tsx
@@ -19,6 +19,7 @@ import {
   withStyles,
 } from '@material-ui/core';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import MonsterAbility from '../../models/MonsterAbility';
 
 /** Setup the styles and theming for this component and children */
 const styles = (theme: Theme) => ({
@@ -62,6 +63,7 @@ export interface MonsterProps {
   weaknesses: Array<string>;
   senses: Array<string>;
   languages: Array<string>;
+  abilities: Array<MonsterAbility>;
   challengeRating: string;
   rewardXP: string;
 }
@@ -74,20 +76,20 @@ class Monster extends Component<{ classes: any }, MonsterProps> {
    * in normal textfields which forces the types to have to be strings
    */
   public state = {
-    name: 'Harold the Destroyer',
-    size: 'Large',
-    alignment: 'Lawful Good',
-    armourClass: '23',
-    hitPoints: '543',
-    hitDie: '12d20',
-    speed: '50 land',
-    str: '20',
-    dex: '20',
-    con: '20',
-    int: '20',
-    wis: '20',
-    chr: '20',
-    profBonus: '12',
+    name: '',
+    size: '',
+    alignment: '',
+    armourClass: '',
+    hitPoints: '',
+    hitDie: '',
+    speed: '',
+    str: '',
+    dex: '',
+    con: '',
+    int: '',
+    wis: '',
+    chr: '',
+    profBonus: '',
     proficiencies: new Array<string>(),
     savingThrows: new Array<string>(),
     immunities: new Array<string>(),
@@ -95,6 +97,7 @@ class Monster extends Component<{ classes: any }, MonsterProps> {
     weaknesses: new Array<string>(),
     languages: new Array<string>(),
     senses: new Array<string>(),
+    abilities: new Array<MonsterAbility>(),
     challengeRating: '',
     rewardXP: '',
     handleChange: '',

--- a/src/components/monster/Monster.tsx
+++ b/src/components/monster/Monster.tsx
@@ -96,7 +96,18 @@ class Monster extends Component<{ classes: any }, MonsterProps> {
     weaknesses: new Array<string>(),
     languages: new Array<string>(),
     senses: new Array<string>(),
-    abilities: new Array<MonsterAbility>(),
+    // abilities: new Array<MonsterAbility>(),
+    abilities: [
+      new MonsterAbility({
+        name: 'Darksight',
+        description: 'Can see in the dark for up to 120ft',
+      }),
+      new MonsterAbility({
+        name: 'Legendary Resistance (3/Day)',
+        description:
+          'If the Dragon fails a saving throw, it can choose to succeed instead.',
+      }),
+    ],
     challengeRating: '',
     rewardXP: '',
     handleChange: '',
@@ -196,7 +207,7 @@ class Monster extends Component<{ classes: any }, MonsterProps> {
             </Typography>
           </ExpansionPanelSummary>
           <ExpansionPanelDetails>
-            <MonsterAbilities />
+            <MonsterAbilities monsterAbilities={this.state.abilities} />
           </ExpansionPanelDetails>
         </ExpansionPanel>
 

--- a/src/components/monster/monster-abilities/AddMonsterAbility.tsx
+++ b/src/components/monster/monster-abilities/AddMonsterAbility.tsx
@@ -5,5 +5,5 @@
 import React from 'react';
 
 export default function AddMonsterAbility() {
-  return <div>Add an ability here</div>;
+  return <div></div>;
 }

--- a/src/components/monster/monster-abilities/MonsterAbilities.tsx
+++ b/src/components/monster/monster-abilities/MonsterAbilities.tsx
@@ -5,12 +5,32 @@
 import React from 'react';
 import AddMonsterAbility from './AddMonsterAbility';
 import MonsterAbilitiesList from './MonsterAbilitiesList';
+import MonsterAbility from '../../../models/MonsterAbility';
+import PropTypes from 'prop-types';
 
-export default function MonsterAbilities() {
-  return (
-    <div>
-      <AddMonsterAbility />
-      <MonsterAbilitiesList />
-    </div>
-  );
+export interface MonsterAbilitiesProps {
+  monsterAbilities: Array<MonsterAbility>;
+  handleChange: any;
+  classes: any;
 }
+
+class MonsterAbilities extends React.Component<MonsterAbilitiesProps> {
+  static propTypes: { [key in keyof MonsterAbilitiesProps]: any } = {
+    monsterAbilities: PropTypes.array.isRequired,
+    handleChange: PropTypes.func.isRequired,
+    classes: PropTypes.object,
+  };
+
+  private handleAddMonsterAbility = (newAbility: MonsterAbility) => {};
+
+  render() {
+    return (
+      <div>
+        <AddMonsterAbility />
+        <MonsterAbilitiesList />
+      </div>
+    );
+  }
+}
+
+export default MonsterAbilities;

--- a/src/components/monster/monster-abilities/MonsterAbilities.tsx
+++ b/src/components/monster/monster-abilities/MonsterAbilities.tsx
@@ -6,31 +6,26 @@ import React from 'react';
 import AddMonsterAbility from './AddMonsterAbility';
 import MonsterAbilitiesList from './MonsterAbilitiesList';
 import MonsterAbility from '../../../models/MonsterAbility';
-import PropTypes from 'prop-types';
+import PropTypes, { InferProps } from 'prop-types';
 
-export interface MonsterAbilitiesProps {
-  monsterAbilities: Array<MonsterAbility>;
-  handleChange: any;
-  classes: any;
+function MonsterAbilities({
+  monsterAbilities,
+  handleChange,
+  classes,
+}: InferProps<typeof MonsterAbilities.propTypes>) {
+  return (
+    <div style={{ width: '100%' }}>
+      <AddMonsterAbility />
+      <MonsterAbilitiesList monsterAbilities={monsterAbilities} />
+    </div>
+  );
 }
 
-class MonsterAbilities extends React.Component<MonsterAbilitiesProps> {
-  static propTypes: { [key in keyof MonsterAbilitiesProps]: any } = {
-    monsterAbilities: PropTypes.array.isRequired,
-    handleChange: PropTypes.func.isRequired,
-    classes: PropTypes.object,
-  };
-
-  private handleAddMonsterAbility = (newAbility: MonsterAbility) => {};
-
-  render() {
-    return (
-      <div>
-        <AddMonsterAbility />
-        <MonsterAbilitiesList />
-      </div>
-    );
-  }
-}
+MonsterAbilities.propTypes = {
+  monsterAbilities: PropTypes.arrayOf(PropTypes.instanceOf(MonsterAbility))
+    .isRequired,
+  handleChange: PropTypes.func,
+  classes: PropTypes.object,
+};
 
 export default MonsterAbilities;

--- a/src/components/monster/monster-abilities/MonsterAbilitiesList.tsx
+++ b/src/components/monster/monster-abilities/MonsterAbilitiesList.tsx
@@ -3,7 +3,35 @@
  * Displays a list of abilities that a monster may have.
  */
 import React from 'react';
+import PropTypes, { InferProps } from 'prop-types';
+import MonsterAbility from '../../../models/MonsterAbility';
+import MonsterAbilityListItem from './MonsterAbilityListItem';
+import { List, withStyles, Theme } from '@material-ui/core';
 
-export default function MonsterAbilitiesList() {
-  return <div>List of Abilitiess</div>;
+const useStyles = (theme: Theme) => ({
+  list: {
+    width: '100%',
+  },
+});
+
+function MonsterAbilitiesList({
+  monsterAbilities,
+  classes,
+}: InferProps<typeof MonsterAbilitiesList.propTypes>) {
+  return (
+    <>
+      <List className={classes.list}>
+        {monsterAbilities.map((ability: MonsterAbility) => (
+          <MonsterAbilityListItem ability={ability} />
+        ))}
+      </List>
+    </>
+  );
 }
+
+MonsterAbilitiesList.propTypes = {
+  monsterAbilities: PropTypes.array.isRequired,
+  classes: PropTypes.any,
+};
+
+export default withStyles(useStyles, { withTheme: true })(MonsterAbilitiesList);

--- a/src/components/monster/monster-abilities/MonsterAbilityListItem.tsx
+++ b/src/components/monster/monster-abilities/MonsterAbilityListItem.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes, { InferProps } from 'prop-types';
+import {
+  ListItem,
+  ListItemText,
+  Divider,
+  ListItemSecondaryAction,
+  IconButton,
+} from '@material-ui/core';
+import MonsterAbility from '../../../models/MonsterAbility';
+import DeleteIcon from '@material-ui/icons/Delete';
+import EditIcon from '@material-ui/icons/Edit';
+
+export default function MonsterAbilityListItem({
+  ability,
+}: InferProps<typeof MonsterAbilityListItem.propTypes>) {
+  return (
+    <>
+      <ListItem>
+        <ListItemText
+          primary={ability.name}
+          secondary={ability.description}
+        ></ListItemText>
+        <ListItemSecondaryAction>
+          <IconButton aria-label="edit ability">
+            <EditIcon />
+          </IconButton>
+          <IconButton aria-label="delete ability">
+            <DeleteIcon style={{ color: '#ff0000' }} />
+          </IconButton>
+        </ListItemSecondaryAction>
+      </ListItem>
+      <Divider />
+    </>
+  );
+}
+
+MonsterAbilityListItem.propTypes = {
+  ability: PropTypes.instanceOf(MonsterAbility).isRequired,
+};

--- a/src/models/MonsterAbility.tsx
+++ b/src/models/MonsterAbility.tsx
@@ -1,5 +1,15 @@
-export default interface MonsterAbility {
+import { v4 as uuidv4 } from 'uuid';
+
+export default class MonsterAbility {
   id: string;
-  abilityName: string;
-  abilityDesc: string;
+  name: string;
+  description: string;
+
+  constructor(init?: Partial<MonsterAbility>) {
+    if (init.id == null) {
+      init.id = uuidv4();
+    }
+
+    Object.assign(this, init);
+  }
 }

--- a/src/models/MonsterAbility.tsx
+++ b/src/models/MonsterAbility.tsx
@@ -1,0 +1,5 @@
+export default interface MonsterAbility {
+  id: string;
+  abilityName: string;
+  abilityDesc: string;
+}


### PR DESCRIPTION
**Monster Abilities**
- Fixed styling so it takes up the width of the container
- Fixed proptypes to now handle custom classes
- Turn Monster Ability interface into a class to handle the above point
- Added monster ability list item and basic styling and displaying
- Added prop-types required for the displaying of the abilities into the list

**Misc** 
- Added UUID package
- Changed up some data to handle the displaying of abilities