### PR TITLE
Monster Action Manipulation Added

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,13 @@ const theme = createMuiTheme({
   palette: {
     primary: {
       main: '#004d00',
+      light: '#3a7a2d',
+      dark: '#002500',
+    },
+    secondary: {
+      main: '#4D0026',
+      light: '#002500',
+      dark: '#2a0000',
     },
   },
 });

--- a/src/components/monster/Monster.tsx
+++ b/src/components/monster/Monster.tsx
@@ -219,8 +219,9 @@ class Monster extends Component<{ classes: any }, MonsterProps> {
    * @param id the id of the ability to remove
    */
   private removeAction = (id: string) => {
+    console.log(id);
     this.setState({
-      abilities: [
+      actions: [
         ...this.state.actions.filter((action: MonsterAction) => action.id !== id),
       ],
     });

--- a/src/components/monster/Monster.tsx
+++ b/src/components/monster/Monster.tsx
@@ -64,6 +64,7 @@ export interface MonsterProps {
   senses: Array<string>;
   languages: Array<string>;
   abilities: Array<MonsterAbility>;
+  actions: Array<MonsterAction>;
   challengeRating: string;
   rewardXP: string;
 }
@@ -187,6 +188,44 @@ class Monster extends Component<{ classes: any }, MonsterProps> {
     });
   };
 
+  /**
+   * Updates an action item if its id is already existing.
+   * If the id doesn't exist it will append the action to the end
+   * @param updatedActopm The action item to update or add
+   */
+  private updateMonsterActions = (updatedAction: MonsterAction) => {
+    // Check to see if we have an already existing ability item
+    const existingIndex: number = this.state.actions.findIndex(
+      (action: MonsterAction) => action.id === updatedAction.id
+    );
+
+    if (existingIndex > -1) {
+      // Copy the array so we don't have a chance to manipulate it before wanted
+      const actions = [...this.state.actions];
+      actions[existingIndex] = new MonsterAction(updatedAction);
+
+      this.setState({
+        actions,
+      });
+    } else {
+      this.setState({
+        actions: [...this.state.actions, new MonsterAction(updatedAction)],
+      });
+    }
+  };
+
+  /**
+   * Removes an action from the state that has the matching id
+   * @param id the id of the ability to remove
+   */
+  private removeAction = (id: string) => {
+    this.setState({
+      abilities: [
+        ...this.state.actions.filter((action: MonsterAction) => action.id !== id),
+      ],
+    });
+  };
+
   render() {
     const { classes } = this.props;
 
@@ -281,7 +320,11 @@ class Monster extends Component<{ classes: any }, MonsterProps> {
             </Typography>
           </ExpansionPanelSummary>
           <ExpansionPanelDetails>
-            <MonsterActions monsterActions={this.state.actions} />
+            <MonsterActions
+              monsterActions={this.state.actions}
+              addMonsterAction={this.updateMonsterActions}
+              removeAction={this.removeAction}
+            />
           </ExpansionPanelDetails>
         </ExpansionPanel>
       </div>

--- a/src/components/monster/monster-abilities/AddMonsterAbility.tsx
+++ b/src/components/monster/monster-abilities/AddMonsterAbility.tsx
@@ -66,6 +66,12 @@ function AddMonsterAbility({
     setIsNew(true);
   };
 
+  /** Cancels editting a monster ability */
+  const cancelEdit = () => {
+    setAbility(new MonsterAbility());
+    setIsNew(true);
+  };
+
   return (
     <>
       <Box
@@ -109,6 +115,17 @@ function AddMonsterAbility({
           >
             {isNew ? 'Save' : 'Update'}
           </Button>
+          {!isNew && (
+            <Button
+              color="secondary"
+              variant="contained"
+              aria-label="Cancel Edit"
+              style={{ marginLeft: '8px' }}
+              onClick={cancelEdit}
+            >
+              Cancel
+            </Button>
+          )}
         </Box>
       </Box>
     </>

--- a/src/components/monster/monster-abilities/MonsterAbilities.tsx
+++ b/src/components/monster/monster-abilities/MonsterAbilities.tsx
@@ -12,8 +12,6 @@ function MonsterAbilities({
   monsterAbilities,
   addMonsterAbility,
   removeAbility,
-  handleChange,
-  classes,
 }: InferProps<typeof MonsterAbilities.propTypes>) {
   const [edittingAbility, setEdittingAbility] = useState(null);
 
@@ -47,8 +45,6 @@ MonsterAbilities.propTypes = {
     .isRequired,
   addMonsterAbility: PropTypes.func.isRequired,
   removeAbility: PropTypes.func.isRequired,
-  handleChange: PropTypes.func,
-  classes: PropTypes.object,
 };
 
 export default MonsterAbilities;

--- a/src/components/monster/monster-actions/AddMonsterAction.tsx
+++ b/src/components/monster/monster-actions/AddMonsterAction.tsx
@@ -114,6 +114,15 @@ function AddMonsterAction({
     setIsNew(true);
   };
 
+  /**
+   * Cancels editting an action setting the state
+   * back to a new state
+   */
+  const cancelEdit = () => {
+    setAction(new MonsterAction());
+    setIsNew(true);
+  };
+
   return (
     <>
       <Box display="flex" flexDirection="row" width="100%">
@@ -122,6 +131,7 @@ function AddMonsterAction({
           aria-label="Action Name"
           name="name"
           className={classes.inputField}
+          value={action.name}
           style={{ width: '33%' }}
         />
         <FormControl className={classes.inputField} style={{ width: '33%' }}>
@@ -232,6 +242,7 @@ function AddMonsterAction({
           label="Description"
           aria-label="Action Description"
           name="description"
+          value={action.description}
           onChange={handleChange}
         />
         <Box
@@ -248,6 +259,17 @@ function AddMonsterAction({
           >
             {isNew ? 'Save' : 'Update'}
           </Button>
+          {!isNew && (
+            <Button
+              color="secondary"
+              variant="contained"
+              aria-label="Cancel Edit"
+              style={{ marginLeft: '8px' }}
+              onClick={cancelEdit}
+            >
+              Cancel
+            </Button>
+          )}
         </Box>
       </Box>
     </>

--- a/src/components/monster/monster-actions/AddMonsterAction.tsx
+++ b/src/components/monster/monster-actions/AddMonsterAction.tsx
@@ -3,7 +3,7 @@
  * Handles adding a singular action for a monster
  * whether it be a regular action, legendary, or lair
  */
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Box,
   TextField,
@@ -13,9 +13,17 @@ import {
   MenuItem,
   Checkbox,
   FormControlLabel,
+  Theme,
+  withStyles,
+  Button,
 } from '@material-ui/core';
 import PropTypes, { InferProps } from 'prop-types';
 import MonsterAction from '../../../models/MonsterAction';
+import { getDamageTypes } from '../../../hooks/getDamageTypes';
+
+const useStyles = (theme: Theme) => ({
+  inputField: { display: 'flex', margin: theme.spacing(1) },
+});
 
 function AddMonsterAction({
   addMonsterAction,
@@ -23,9 +31,56 @@ function AddMonsterAction({
   classes,
 }: InferProps<typeof AddMonsterAction.propTypes>) {
   const [action, setAction] = useState(new MonsterAction({}));
+  const [isNew, setIsNew] = useState(true);
 
   /** List of action types available in 5e */
   const actionTypes: Array<string> = ['Action', 'Reaction', 'Legendary'];
+
+  const attackTypes: Array<string> = [
+    'Melee Weapon Attack',
+    'Ranged Weapon Attack',
+    'Melee Spell Attack',
+    'Ranged Spell Attack',
+  ];
+
+  const damageTypes: Array<string> = getDamageTypes();
+
+  /**
+   * Effect used to set attack parameters to null if the isAttack
+   * parameter is set to false
+   */
+  useEffect(() => {
+    if (!action.isAttack) {
+      setAction({
+        ...action,
+        attackType: null,
+        toHit: null,
+        damage: null,
+        damageType: null,
+        reach: null,
+      });
+    }
+  }, [action.isAttack]);
+
+  /**
+   * An effect that checks if the editAction prop has been change
+   * When it does, it sets the action being editted to that if it isn't null
+   * and sets the isNew state to false. If it is null it just creates a
+   * new blank monster action and sets the isNew state to false
+   */
+  useEffect(() => {
+    if (editAction == null) {
+      setIsNew(true);
+      setAction(new MonsterAction({}));
+    } else {
+      setIsNew(false);
+      setAction(editAction);
+    }
+
+    return () => {
+      setAction(new MonsterAction({}));
+    };
+  }, [editAction]);
 
   /**
    * Handles updating the
@@ -49,11 +104,27 @@ function AddMonsterAction({
     });
   };
 
+  /**
+   * Add or edit a monster action by passing it up to the parent
+   * and then reset the state of the action inputs
+   */
+  const addAction = () => {
+    addMonsterAction(action);
+    setAction(new MonsterAction());
+    setIsNew(true);
+  };
+
   return (
     <>
       <Box display="flex" flexDirection="row" width="100%">
-        <TextField label="Name" aria-label="Action Name" name="name" />
-        <FormControl>
+        <TextField
+          label="Name"
+          aria-label="Action Name"
+          name="name"
+          className={classes.inputField}
+          style={{ width: '33%' }}
+        />
+        <FormControl className={classes.inputField} style={{ width: '33%' }}>
           <InputLabel id="action-type-label" aria-label="Action Type">
             Type
           </InputLabel>
@@ -81,12 +152,103 @@ function AddMonsterAction({
               color="primary"
             />
           }
+          className={classes.inputField}
+          style={{ width: '33%' }}
         />
+      </Box>
+      {action.isAttack && (
+        <>
+          <Box display="flex" flexDirection="row" width="100%">
+            <FormControl className={classes.inputField} style={{ width: '33%' }}>
+              <InputLabel id="attack-type-label" aria-label="Attack Type">
+                Attack Type
+              </InputLabel>
+              <Select
+                name="attackType"
+                labelId="attack-type-label"
+                value={action.attackType}
+                onChange={handleChange}
+              >
+                {attackTypes.map((attackType: string) => (
+                  <MenuItem key={attackType} value={attackType}>
+                    {attackType}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <TextField
+              name="reach"
+              label="Reach"
+              aria-label="React"
+              value={action.reach}
+              onChange={handleChange}
+              className={classes.inputField}
+              style={{ width: '33%' }}
+            />
+            <TextField
+              name="toHit"
+              label="To Hit"
+              aria-label="To Hit"
+              value={action.toHit}
+              onChange={handleChange}
+              className={classes.inputField}
+              style={{ width: '33%' }}
+            />
+          </Box>
+          <Box display="flex" flexDirection="row" width="100%">
+            <TextField
+              name="damage"
+              label="Damage"
+              aria-label="Damage"
+              value={action.damage}
+              onChange={handleChange}
+              className={classes.inputField}
+              style={{ width: '50%' }}
+            />
+            <FormControl className={classes.inputField} style={{ width: '50%' }}>
+              <InputLabel id="damage-type-label" aria-label="Damage Type">
+                Damage Type
+              </InputLabel>
+              <Select
+                name="damageType"
+                labelId="damage-type-label"
+                value={action.damageType}
+                onChange={handleChange}
+              >
+                {damageTypes.map((damageType: string) => (
+                  <MenuItem key={damageType} value={damageType}>
+                    {damageType}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Box>
+        </>
+      )}
+      <Box display="flex" flexDirection="row" width="100%">
         <TextField
+          className={classes.inputField}
+          style={{ width: '85%' }}
           label="Description"
           aria-label="Action Description"
           name="description"
+          onChange={handleChange}
         />
+        <Box
+          width="15%"
+          justifyContent="flex-end"
+          display="flex"
+          alignItems="center"
+        >
+          <Button
+            color="primary"
+            variant="contained"
+            aria-label="Save Action"
+            onClick={addAction}
+          >
+            {isNew ? 'Save' : 'Update'}
+          </Button>
+        </Box>
       </Box>
     </>
   );
@@ -98,4 +260,4 @@ AddMonsterAction.propTypes = {
   classes: PropTypes.any,
 };
 
-export default AddMonsterAction;
+export default withStyles(useStyles, { withTheme: true })(AddMonsterAction);

--- a/src/components/monster/monster-actions/AddMonsterAction.tsx
+++ b/src/components/monster/monster-actions/AddMonsterAction.tsx
@@ -3,8 +3,99 @@
  * Handles adding a singular action for a monster
  * whether it be a regular action, legendary, or lair
  */
-import React from 'react';
+import React, { useState } from 'react';
+import {
+  Box,
+  TextField,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Checkbox,
+  FormControlLabel,
+} from '@material-ui/core';
+import PropTypes, { InferProps } from 'prop-types';
+import MonsterAction from '../../../models/MonsterAction';
 
-export default function AddMonsterAction() {
-  return <div></div>;
+function AddMonsterAction({
+  addMonsterAction,
+  editAction,
+  classes,
+}: InferProps<typeof AddMonsterAction.propTypes>) {
+  const [action, setAction] = useState(new MonsterAction({}));
+
+  /** List of action types available in 5e */
+  const actionTypes: Array<string> = ['Action', 'Reaction', 'Legendary'];
+
+  /**
+   * Handles updating the
+   * @param event the event emitted from material's inputs
+   */
+  const handleChange = (event: any) => {
+    setAction({
+      ...action,
+      [event.target.name]: event.target.value,
+    });
+  };
+
+  /**
+   * Updates the checkbox being marked / unmarked
+   * @param event the event emitted from Material's checkbox
+   */
+  const handleCheck = (event: any) => {
+    setAction({
+      ...action,
+      [event.target.name]: event.target.checked,
+    });
+  };
+
+  return (
+    <>
+      <Box display="flex" flexDirection="row" width="100%">
+        <TextField label="Name" aria-label="Action Name" name="name" />
+        <FormControl>
+          <InputLabel id="action-type-label" aria-label="Action Type">
+            Type
+          </InputLabel>
+          <Select
+            name="actionType"
+            labelId="action-type-label"
+            value={action.actionType}
+            onChange={handleChange}
+          >
+            {actionTypes.map((actionType: string) => (
+              <MenuItem key={actionType} value={actionType}>
+                {actionType}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <FormControlLabel
+          label="Is Attack"
+          aria-label="Is Attack Action"
+          control={
+            <Checkbox
+              checked={action.isAttack}
+              onChange={handleCheck}
+              name="isAttack"
+              color="primary"
+            />
+          }
+        />
+        <TextField
+          label="Description"
+          aria-label="Action Description"
+          name="description"
+        />
+      </Box>
+    </>
+  );
 }
+
+AddMonsterAction.propTypes = {
+  addMonsterAction: PropTypes.func.isRequired,
+  editAction: PropTypes.instanceOf(MonsterAction),
+  classes: PropTypes.any,
+};
+
+export default AddMonsterAction;

--- a/src/components/monster/monster-actions/MonsterActionListItem.tsx
+++ b/src/components/monster/monster-actions/MonsterActionListItem.tsx
@@ -35,7 +35,10 @@ function MonsterActionListItem({
       <ListItem>
         <ListItemText primary={action.name} secondary={actionSummary}></ListItemText>
         <ListItemSecondaryAction>
-          <IconButton aria-label="edit ability" onClick={editAction}>
+          <IconButton
+            aria-label="edit ability"
+            onClick={editAction.bind(this, action)}
+          >
             <EditIcon />
           </IconButton>
           <IconButton

--- a/src/components/monster/monster-actions/MonsterActionListItem.tsx
+++ b/src/components/monster/monster-actions/MonsterActionListItem.tsx
@@ -13,6 +13,8 @@ import PropTypes, { InferProps } from 'prop-types';
 
 function MonsterActionListItem({
   action,
+  removeAction,
+  editAction,
 }: InferProps<typeof MonsterActionListItem.propTypes>) {
   const [actionSummary, setActionSummary] = useState('');
 
@@ -33,10 +35,10 @@ function MonsterActionListItem({
       <ListItem>
         <ListItemText primary={action.name} secondary={actionSummary}></ListItemText>
         <ListItemSecondaryAction>
-          <IconButton aria-label="edit ability">
+          <IconButton aria-label="edit ability" onClick={editAction}>
             <EditIcon />
           </IconButton>
-          <IconButton aria-label="delete ability">
+          <IconButton aria-label="delete ability" onClick={removeAction}>
             <DeleteIcon style={{ color: '#ff0000' }} />
           </IconButton>
         </ListItemSecondaryAction>
@@ -48,6 +50,8 @@ function MonsterActionListItem({
 
 MonsterActionListItem.propTypes = {
   action: PropTypes.instanceOf(MonsterAction).isRequired,
+  removeAction: PropTypes.func.isRequired,
+  editAction: PropTypes.func.isRequired,
 };
 
 export default MonsterActionListItem;

--- a/src/components/monster/monster-actions/MonsterActionListItem.tsx
+++ b/src/components/monster/monster-actions/MonsterActionListItem.tsx
@@ -38,7 +38,10 @@ function MonsterActionListItem({
           <IconButton aria-label="edit ability" onClick={editAction}>
             <EditIcon />
           </IconButton>
-          <IconButton aria-label="delete ability" onClick={removeAction}>
+          <IconButton
+            aria-label="delete ability"
+            onClick={removeAction.bind(this, action.id)}
+          >
             <DeleteIcon style={{ color: '#ff0000' }} />
           </IconButton>
         </ListItemSecondaryAction>

--- a/src/components/monster/monster-actions/MonsterActions.tsx
+++ b/src/components/monster/monster-actions/MonsterActions.tsx
@@ -2,7 +2,7 @@
  * MonsterActions.tsx
  * Handles the management and display of the monster actions
  */
-import React from 'react';
+import React, { useState } from 'react';
 import AddMonsterAction from './AddMonsterAction';
 import MonsterActionsList from './MonsterActionsList';
 import MonsterAction from '../../../models/MonsterAction';
@@ -10,12 +10,27 @@ import PropTypes, { InferProps } from 'prop-types';
 
 function MonsterActions({
   monsterActions,
-  handleChange,
-  classes,
+  addMonsterAction,
+  removeAction,
 }: InferProps<typeof MonsterActions.propTypes>) {
+  const [edittingAction, setEdittingAction] = useState(null);
+
+  /**
+   * Sets the action we are editting so the child
+   * add monster action gets the state that it is editting
+   * an existing one
+   * @param action the action we are editting
+   */
+  const editAction = (action: MonsterAction) => {
+    setEdittingAction(action);
+  };
+
   return (
     <div style={{ width: '100%' }}>
-      <AddMonsterAction />
+      <AddMonsterAction
+        addMonsterAction={addMonsterAction}
+        editAction={edittingAction}
+      />
       <MonsterActionsList monsterActions={monsterActions} />
     </div>
   );
@@ -23,8 +38,8 @@ function MonsterActions({
 
 MonsterActions.propTypes = {
   monsterActions: PropTypes.arrayOf(PropTypes.instanceOf(MonsterAction)).isRequired,
-  handleChange: PropTypes.func,
-  classes: PropTypes.object,
+  addMonsterAction: PropTypes.func.isRequired,
+  removeAction: PropTypes.func.isRequired,
 };
 
 export default MonsterActions;

--- a/src/components/monster/monster-actions/MonsterActions.tsx
+++ b/src/components/monster/monster-actions/MonsterActions.tsx
@@ -31,7 +31,11 @@ function MonsterActions({
         addMonsterAction={addMonsterAction}
         editAction={edittingAction}
       />
-      <MonsterActionsList monsterActions={monsterActions} />
+      <MonsterActionsList
+        monsterActions={monsterActions}
+        removeAction={removeAction}
+        editAction={editAction}
+      />
     </div>
   );
 }

--- a/src/components/monster/monster-actions/MonsterActionsList.tsx
+++ b/src/components/monster/monster-actions/MonsterActionsList.tsx
@@ -16,13 +16,20 @@ const useStyles = () => ({
 
 function MonsterActionsList({
   monsterActions,
+  removeAction,
+  editAction,
   classes,
 }: InferProps<typeof MonsterActionsList.propTypes>) {
   return (
     <>
       <List className={classes.list}>
         {monsterActions.map((action: MonsterAction) => (
-          <MonsterActionListItem key={action.id} action={action} />
+          <MonsterActionListItem
+            key={action.id}
+            action={action}
+            removeAction={removeAction}
+            editAction={editAction}
+          />
         ))}
       </List>
     </>
@@ -31,6 +38,8 @@ function MonsterActionsList({
 
 MonsterActionsList.propTypes = {
   monsterActions: PropTypes.array.isRequired,
+  removeAction: PropTypes.func.isRequired,
+  editAction: PropTypes.func.isRequired,
   classes: PropTypes.any,
 };
 

--- a/src/components/monster/monster-properties/MonsterProperties.tsx
+++ b/src/components/monster/monster-properties/MonsterProperties.tsx
@@ -14,6 +14,7 @@ import {
   Box,
 } from '@material-ui/core';
 import PropTypes, { InferProps } from 'prop-types';
+import { getDamageTypes } from '../../../hooks/getDamageTypes';
 
 /** Setup the styling for these inputs */
 const useStyles = (theme: Theme) => ({
@@ -40,54 +41,38 @@ function MonsterProperties({
   /**
    * A list of available damage types in 5e
    */
-  const damageTypes: Array<{ value: string; name: string }> = [
-    { value: 'acd', name: 'Acid' },
-    { value: 'cld', name: 'Cold' },
-    { value: 'fre', name: 'Fire' },
-    { value: 'fce', name: 'Force' },
-    { value: 'lgh', name: 'Lightning' },
-    { value: 'nec', name: 'Necrotic' },
-    { value: 'psn', name: 'Poison' },
-    { value: 'psy', name: 'Psychic' },
-    { value: 'rad', name: 'Radiant' },
-    { value: 'thun', name: 'Thunder' },
-    { value: 'nmag', name: 'Non-Magical' },
-    { value: 'wmag', name: 'Magic Weapons' },
-    { value: 'blu', name: 'Bludgeoning' },
-    { value: 'slsh', name: 'Slashing' },
-    { value: 'prc', name: 'Piercing' },
-  ];
+  const damageTypes: Array<string> = getDamageTypes();
 
   /**
    * A list of available senses in 5e
    */
-  const availableSenses: Array<{ value: string; name: string }> = [
-    { value: 'bld', name: 'Blindsight' },
-    { value: 'drk', name: 'Darkvision' },
-    { value: 'tmr', name: 'Tremorsense' },
-    { value: 'tru', name: 'Truesight' },
+  const availableSenses: Array<string> = [
+    'Blindsight',
+    'Darkvision',
+    'Tremorsense',
+    'Truesight',
   ];
 
   /**
    * A list of available languages in 5e
    */
-  const availableLanguages: Array<{ value: string; name: string }> = [
-    { value: 'com', name: 'Common' },
-    { value: 'dwv', name: 'Dwarvish' },
-    { value: 'elv', name: 'Elvish' },
-    { value: 'gnt', name: 'Giant' },
-    { value: 'gnm', name: 'Gnomish' },
-    { value: 'gob', name: 'Goblin' },
-    { value: 'hfl', name: 'Halfling' },
-    { value: 'orc', name: 'Orc' },
-    { value: 'aby', name: 'Abyssal' },
-    { value: 'cel', name: 'Celestial' },
-    { value: 'dra', name: 'Draconic' },
-    { value: 'dps', name: 'Deep Speech' },
-    { value: 'inf', name: 'Infernal' },
-    { value: 'pri', name: 'Primordial' },
-    { value: 'syl', name: 'Sylvan' },
-    { value: 'undr', name: 'Undercommon' },
+  const availableLanguages: Array<string> = [
+    'Dwarvish',
+    'Common',
+    'Elvish',
+    'Giant',
+    'Gnomish',
+    'Goblin',
+    'Halfling',
+    'Orc',
+    'Abyssal',
+    'Celestial',
+    'Draconic',
+    'Deep Speech',
+    'Infernal',
+    'Primordial',
+    'Sylvan',
+    'Undercommon',
   ];
 
   return (
@@ -102,9 +87,9 @@ function MonsterProperties({
             value={immunities}
             onChange={handleChange}
           >
-            {damageTypes.map((damageType: { value: string; name: string }) => (
-              <MenuItem key={damageType.value} value={damageType.value}>
-                {damageType.name}
+            {damageTypes.map((damageType: string) => (
+              <MenuItem key={damageType} value={damageType}>
+                {damageType}
               </MenuItem>
             ))}
           </Select>
@@ -118,9 +103,9 @@ function MonsterProperties({
             value={resistances}
             onChange={handleChange}
           >
-            {damageTypes.map((damageType: { value: string; name: string }) => (
-              <MenuItem key={damageType.value} value={damageType.value}>
-                {damageType.name}
+            {damageTypes.map((damageType: string) => (
+              <MenuItem key={damageType} value={damageType}>
+                {damageType}
               </MenuItem>
             ))}
           </Select>
@@ -134,9 +119,9 @@ function MonsterProperties({
             value={weaknesses}
             onChange={handleChange}
           >
-            {damageTypes.map((damageType: { value: string; name: string }) => (
-              <MenuItem key={damageType.value} value={damageType.value}>
-                {damageType.name}
+            {damageTypes.map((damageType: string) => (
+              <MenuItem key={damageType} value={damageType}>
+                {damageType}
               </MenuItem>
             ))}
           </Select>
@@ -152,9 +137,9 @@ function MonsterProperties({
             value={senses}
             onChange={handleChange}
           >
-            {availableSenses.map((sense: { value: string; name: string }) => (
-              <MenuItem key={sense.value} value={sense.value}>
-                {sense.name}
+            {availableSenses.map((sense: string) => (
+              <MenuItem key={sense} value={sense}>
+                {sense}
               </MenuItem>
             ))}
           </Select>
@@ -168,9 +153,9 @@ function MonsterProperties({
             value={languages}
             onChange={handleChange}
           >
-            {availableLanguages.map((language: { value: string; name: string }) => (
-              <MenuItem key={language.value} value={language.value}>
-                {language.name}
+            {availableLanguages.map((language: string) => (
+              <MenuItem key={language} value={language}>
+                {language}
               </MenuItem>
             ))}
           </Select>

--- a/src/hooks/getDamageTypes.tsx
+++ b/src/hooks/getDamageTypes.tsx
@@ -1,0 +1,22 @@
+/**
+ * Returns all the possible damage types available in 5e
+ */
+export const getDamageTypes = () => {
+  return [
+    'Acid',
+    'Cold',
+    'Fire',
+    'Force',
+    'Lightning',
+    'Necrotic',
+    'Poison',
+    'Psychic',
+    'Radiant',
+    'Thunder',
+    'Non-Magical',
+    'Magic Weapons',
+    'Bludgeoning',
+    'Slashing',
+    'Piercing',
+  ];
+};

--- a/src/models/MonsterAction.tsx
+++ b/src/models/MonsterAction.tsx
@@ -1,21 +1,17 @@
 import { v4 as uuidv4 } from 'uuid';
 
 export default class MonsterAction {
-  id: string;
-  name: string;
-  description: string;
-  actionType: string;
-  attackType?: string;
-  toHit?: string;
-  damage?: string;
-  damageType?: string;
-  reach?: string;
+  public id: string = uuidv4();
+  public name: string = '';
+  public description: string = '';
+  public actionType: string = '';
+  public attackType?: string;
+  public toHit?: string;
+  public damage?: string;
+  public damageType?: string;
+  public reach?: string;
 
   constructor(init?: Partial<MonsterAction>) {
-    if (init.id == null) {
-      init.id = uuidv4();
-    }
-
     Object.assign(this, init);
   }
 }

--- a/src/models/MonsterAction.tsx
+++ b/src/models/MonsterAction.tsx
@@ -5,6 +5,7 @@ export default class MonsterAction {
   public name: string = '';
   public description: string = '';
   public actionType: string = '';
+  public isAttack: boolean = false;
   public attackType?: string;
   public toHit?: string;
   public damage?: string;


### PR DESCRIPTION
**Monster Actions**
- Added the ability to add, edit and delete monster actions

**Monster Abilities**
- Added the ability to cancel out of editing a monster ability

**Misc**
- Added secondary colour theme
- Modified the select value array to use only the display name as the key/val pair didn't really matter
- Added getDamageTypes hook