### PR TITLE
Added Senses, Statblock formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,27 @@ Currently can be found at: https://tjcowx.github.io/5e-homebrew-monsters/
 
 ## VERSIONS
 
+### 0.3.0 (2020-10-06)
+
+- Added Passive perception into the stat block. This only shows up if the monster is proficient in perception
+- Speed is now moved from a text input into it's own set of fields which have the speeds setup via their own property
+- Senses have moved from a multi-select into it's own set of fields where you can put the range of the sense
+- Added Roll20 monster help guide to the navigation menu
+- Fixed an issue where the image may be cut off. This requires the page to scroll to the top to work functionally before it exports now
+- Updated expansion panel headers to describe what is inside it better.
+- Added standard legendary action summary to the Legendary Actions section of the stat block
+
 ### 0.2.2 (2020-09-29)
+
 - Added navigation bar to link to 5-homebrew-items
 - Added version number on the site to quick reference it
 
 ### 0.2.1 (2020-09-17)
+
 - Added the type field to the stat builder
 
 ### 0.2.0 (2020-09-16)
+
 - Added the stat block generator. Image generation is still yet to come
 
 ### 0.1.0

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "5e-homebrew-monsters",
   "homepage": "https://tjcowx.github.io/5e-homebrew-monsters/",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.10.2",

--- a/src/components/monster/Monster.tsx
+++ b/src/components/monster/Monster.tsx
@@ -220,6 +220,8 @@ function Monster({ classes }: InferProps<typeof Monster.propTypes>) {
    * Export the stat block into an image
    */
   const exportImage = () => {
+    // This is a fix to the image not exporting properly
+    window.scroll(0, 0);
     // The below needs to be here otherwise html2canvas can't handle svgs
     // https://stackoverflow.com/questions/32481054/svg-not-displayed-when-using-html2canvas
     var svgElements = document.body.querySelectorAll('svg');
@@ -267,7 +269,7 @@ function Monster({ classes }: InferProps<typeof Monster.propTypes>) {
         armourClass: '17',
         hitPoints: '135',
         hitDie: '18d8+54',
-        speed: '30',
+        landSpeed: '30',
         str: '11',
         dex: '16',
         con: '16',

--- a/src/components/monster/Monster.tsx
+++ b/src/components/monster/Monster.tsx
@@ -11,6 +11,7 @@ import MonsterActions from './monster-actions/MonsterActions';
 import MonsterAbilities from './monster-abilities/MonsterAbilities';
 import MonsterDescription from './monster-descriptions/MonsterDescription';
 import MonsterSpeed from './monster-speed/MonsterSpeed';
+import MonsterSenses from './monster-senses/MonsterSenses';
 import {
   ExpansionPanel,
   ExpansionPanelSummary,
@@ -443,6 +444,24 @@ function Monster({ classes }: InferProps<typeof Monster.propTypes>) {
               profBonus={monster.profBonus}
               proficiencies={monster.proficiencies}
               savingThrows={monster.savingThrows}
+            />
+          </ExpansionPanelDetails>
+        </ExpansionPanel>
+
+        <ExpansionPanel>
+          <ExpansionPanelSummary>
+            <Typography className={classes.heading}>Senses</Typography>
+            <Typography className={classes.secondaryHeading}>
+              Truesight, Tremorsense, ect..
+            </Typography>
+          </ExpansionPanelSummary>
+          <ExpansionPanelDetails>
+            <MonsterSenses
+              blindsight={monster.blindsight}
+              darkvision={monster.darkvision}
+              tremorsense={monster.tremorsense}
+              truesight={monster.truesight}
+              handleChange={handleChange}
             />
           </ExpansionPanelDetails>
         </ExpansionPanel>

--- a/src/components/monster/Monster.tsx
+++ b/src/components/monster/Monster.tsx
@@ -387,9 +387,9 @@ function Monster({ classes }: InferProps<typeof Monster.propTypes>) {
       <Box className={classes.monsterContainer}>
         <ExpansionPanel>
           <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
-            <Typography className={classes.heading}>Monster Description</Typography>
+            <Typography className={classes.heading}>Description</Typography>
             <Typography className={classes.secondaryHeading}>
-              {monster.name}
+              Name, Type, Size, Alignment
             </Typography>
           </ExpansionPanelSummary>
           <ExpansionPanelDetails>
@@ -424,9 +424,9 @@ function Monster({ classes }: InferProps<typeof Monster.propTypes>) {
 
         <ExpansionPanel>
           <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
-            <Typography className={classes.heading}>Monster Stats</Typography>
+            <Typography className={classes.heading}>Stats</Typography>
             <Typography className={classes.secondaryHeading}>
-              Stat-Summary
+              Stats, AC, HP, Proficiencies, Saving Throws
             </Typography>
           </ExpansionPanelSummary>
           <ExpansionPanelDetails>
@@ -468,9 +468,9 @@ function Monster({ classes }: InferProps<typeof Monster.propTypes>) {
 
         <ExpansionPanel>
           <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
-            <Typography className={classes.heading}>Monster Properties</Typography>
+            <Typography className={classes.heading}>Properties</Typography>
             <Typography className={classes.secondaryHeading}>
-              Property Summary
+              Immunities, Resistances, Weaknesses, Languages, CR
             </Typography>
           </ExpansionPanelSummary>
           <ExpansionPanelDetails>
@@ -489,9 +489,9 @@ function Monster({ classes }: InferProps<typeof Monster.propTypes>) {
 
         <ExpansionPanel>
           <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
-            <Typography className={classes.heading}>Monster Abilities</Typography>
+            <Typography className={classes.heading}>Abilities</Typography>
             <Typography className={classes.secondaryHeading}>
-              Ability Summary
+              Passive abilities for the monster
             </Typography>
           </ExpansionPanelSummary>
           <ExpansionPanelDetails>
@@ -505,9 +505,9 @@ function Monster({ classes }: InferProps<typeof Monster.propTypes>) {
 
         <ExpansionPanel>
           <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
-            <Typography className={classes.heading}>Monster Actions</Typography>
+            <Typography className={classes.heading}>Actions</Typography>
             <Typography className={classes.secondaryHeading}>
-              Action Summary
+              Actions, Legendary Actions, Reactions, Lair Actions
             </Typography>
           </ExpansionPanelSummary>
           <ExpansionPanelDetails>

--- a/src/components/monster/Monster.tsx
+++ b/src/components/monster/Monster.tsx
@@ -449,7 +449,7 @@ function Monster({ classes }: InferProps<typeof Monster.propTypes>) {
         </ExpansionPanel>
 
         <ExpansionPanel>
-          <ExpansionPanelSummary>
+          <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
             <Typography className={classes.heading}>Senses</Typography>
             <Typography className={classes.secondaryHeading}>
               Truesight, Tremorsense, ect..
@@ -480,7 +480,6 @@ function Monster({ classes }: InferProps<typeof Monster.propTypes>) {
               resistances={monster.resistances}
               weaknesses={monster.weaknesses}
               languages={monster.languages}
-              senses={monster.senses}
               challengeRating={monster.challengeRating}
               rewardXP={monster.rewardXP}
               handleChange={handleChange}

--- a/src/components/monster/Monster.tsx
+++ b/src/components/monster/Monster.tsx
@@ -291,7 +291,7 @@ function Monster({ classes }: InferProps<typeof Monster.propTypes>) {
           'Paralyzed',
           'Poisoned',
         ],
-        senses: ['Truesight'],
+        truesight: '120',
         languages: ['Common', 'Elvish', 'Celestial', 'Sylvan', 'Primordial'],
         abilities: [
           new MonsterAbility({

--- a/src/components/monster/monster-properties/MonsterProperties.tsx
+++ b/src/components/monster/monster-properties/MonsterProperties.tsx
@@ -33,7 +33,6 @@ function MonsterProperties({
   resistances,
   weaknesses,
   condImmunities,
-  senses,
   languages,
   challengeRating,
   rewardXP,
@@ -167,23 +166,7 @@ function MonsterProperties({
         </FormControl>
       </Box>
       <Box display="flex" flexDirection="row">
-        <FormControl className={classes.inputField} style={{ width: '25%' }}>
-          <InputLabel id="senses-label">Senses</InputLabel>
-          <Select
-            name="senses"
-            multiple
-            labelId="senses-label"
-            value={senses}
-            onChange={handleChange}
-          >
-            {availableSenses.map((sense: string) => (
-              <MenuItem key={sense} value={sense}>
-                {sense}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
-        <FormControl className={classes.inputField} style={{ width: '25%' }}>
+        <FormControl className={classes.inputField} style={{ width: '33%' }}>
           <InputLabel id="languages-label">Languages</InputLabel>
           <Select
             name="languages"
@@ -201,7 +184,7 @@ function MonsterProperties({
         </FormControl>
         <TextField
           className={classes.inputField}
-          style={{ width: '25%' }}
+          style={{ width: '33%' }}
           id="standard-basic"
           label="Challenge Rating"
           name="challengeRating"
@@ -210,7 +193,7 @@ function MonsterProperties({
         />
         <TextField
           className={classes.inputField}
-          style={{ width: '25%' }}
+          style={{ width: '33%' }}
           id="standard-basic"
           label="Reward XP"
           name="rewardXP"
@@ -228,7 +211,6 @@ MonsterProperties.propTypes = {
   resistances: PropTypes.array.isRequired,
   weaknesses: PropTypes.array.isRequired,
   languages: PropTypes.array.isRequired,
-  senses: PropTypes.array.isRequired,
   challengeRating: PropTypes.string.isRequired,
   rewardXP: PropTypes.string.isRequired,
   handleChange: PropTypes.func.isRequired,

--- a/src/components/monster/monster-senses/MonsterSenses.tsx
+++ b/src/components/monster/monster-senses/MonsterSenses.tsx
@@ -10,7 +10,7 @@ import React, { useEffect, useState } from 'react';
 
 const useStyles = makeStyles(() => ({
   senseToggle: {
-    minWidth: '116px',
+    minWidth: '170px',
     paddingRight: '8px',
     marginTop: 'auto',
   },

--- a/src/components/monster/monster-senses/MonsterSenses.tsx
+++ b/src/components/monster/monster-senses/MonsterSenses.tsx
@@ -1,0 +1,118 @@
+import { Box, FormControlLabel, makeStyles, Switch } from '@material-ui/core';
+import propTypes, { InferProps } from 'prop-types';
+import React, { useState } from 'react';
+
+const useStyles = makeStyles(() => ({
+  senseToggle: {
+    minWidth: '116px',
+    paddingRight: '8px',
+    marginTop: 'auto',
+  },
+}));
+
+function MonsterSenses({
+  blindsight,
+  darkvision,
+  tremorsense,
+  truesight,
+  handleChange,
+}: InferProps<typeof MonsterSenses.propTypes>) {
+  const [hasBlind, setHasBlind] = useState(blindsight !== '');
+  const [hasDark, setHasDark] = useState(darkvision !== '');
+  const [hasTremor, setHasTremor] = useState(tremorsense != '');
+  const [hasTruesight, setHasTruesight] = useState(truesight != '');
+
+  /** Classes for the component */
+  const classes = useStyles();
+
+  /** Toggles the senses show availablity */
+  const toggleSenseShow = (sense: string) => {
+    switch (sense) {
+      case 'blind':
+        setHasBlind(!hasBlind);
+        break;
+      case 'dark':
+        setHasDark(!hasDark);
+        break;
+      case 'tremor':
+        setHasTremor(!hasTremor);
+        break;
+      case 'trueSight':
+        setHasTruesight(!hasTruesight);
+        break;
+      default:
+        console.error(`${sense} isn't a sense`);
+    }
+  };
+
+  return (
+    <Box width="100%">
+      <Box display="flex" flexDirection="row">
+        <div className={classes.senseToggle}>
+          <FormControlLabel
+            label="Blindsight"
+            control={
+              <Switch
+                color="primary"
+                checked={hasBlind}
+                onChange={() => toggleSenseShow('blind')}
+              />
+            }
+          />
+        </div>
+      </Box>
+      <Box display="flex" flexDirection="row">
+        <div className={classes.senseToggle}>
+          <FormControlLabel
+            label="Darkvision"
+            control={
+              <Switch
+                color="primary"
+                checked={hasDark}
+                onChange={() => toggleSenseShow('dark')}
+              />
+            }
+          />
+        </div>
+      </Box>
+      <Box display="flex" flexDirection="row">
+        <div className={classes.senseToggle}>
+          <FormControlLabel
+            label="Tremorsense"
+            control={
+              <Switch
+                color="primary"
+                checked={hasTremor}
+                onChange={() => toggleSenseShow('tremor')}
+              />
+            }
+          />
+        </div>
+      </Box>
+      <Box display="flex" flexDirection="row">
+        <div className={classes.senseToggle}>
+          <FormControlLabel
+            label="Truesight"
+            control={
+              <Switch
+                color="primary"
+                checked={hasTruesight}
+                onChange={() => toggleSenseShow('trueSight')}
+              />
+            }
+          />
+        </div>
+      </Box>
+    </Box>
+  );
+}
+
+MonsterSenses.propTypes = {
+  blindsight: propTypes.string,
+  darkvision: propTypes.string,
+  tremorsense: propTypes.string,
+  truesight: propTypes.string,
+  handleChange: propTypes.func,
+};
+
+export default MonsterSenses;

--- a/src/components/monster/monster-senses/MonsterSenses.tsx
+++ b/src/components/monster/monster-senses/MonsterSenses.tsx
@@ -1,6 +1,12 @@
-import { Box, FormControlLabel, makeStyles, Switch } from '@material-ui/core';
+import {
+  Box,
+  FormControlLabel,
+  makeStyles,
+  Switch,
+  TextField,
+} from '@material-ui/core';
 import propTypes, { InferProps } from 'prop-types';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 const useStyles = makeStyles(() => ({
   senseToggle: {
@@ -25,6 +31,54 @@ function MonsterSenses({
   /** Classes for the component */
   const classes = useStyles();
 
+  // **************************************
+  //#region     EFFECT HOOKS
+  // **************************************
+
+  /** Setup the effect to toggle if blindsight is available or not */
+  useEffect(() => {
+    handleChange({
+      target: {
+        name: 'blindsight',
+        value: !hasBlind ? '' : blindsight,
+      },
+    });
+  }, [hasBlind]);
+
+  /** Setup the effect to toggle if darkvision is available or not */
+  useEffect(() => {
+    handleChange({
+      target: {
+        name: 'darkvision',
+        value: !hasDark ? '' : darkvision,
+      },
+    });
+  }, [hasDark]);
+
+  /** Setup the effect to toggle if tremorsense is available or not */
+  useEffect(() => {
+    handleChange({
+      target: {
+        name: 'tremorsense',
+        value: !hasTremor ? '' : tremorsense,
+      },
+    });
+  }, [hasTremor]);
+
+  /** Setup the effect to toggle if truesight is available or not */
+  useEffect(() => {
+    handleChange({
+      target: {
+        name: 'truesight',
+        value: !hasTruesight ? '' : truesight,
+      },
+    });
+  }, [hasTruesight]);
+
+  // **************************************
+  //#endregion  END EFFECT HOOKS
+  // **************************************
+
   /** Toggles the senses show availablity */
   const toggleSenseShow = (sense: string) => {
     switch (sense) {
@@ -45,6 +99,18 @@ function MonsterSenses({
     }
   };
 
+  /**
+   * Takes an input event and checks to see if it was an integer input
+   * before trying to update the state
+   * @param event The event passed in from material UI onChange
+   */
+  const handleIntChange = (event: { target: { name: any; value: any } }) => {
+    // If it's null or a number value we will let it update the state in the parent
+    if (event.target.value == null || /^-?[0-9]*$/.test(event.target.value)) {
+      handleChange(event);
+    }
+  };
+
   return (
     <Box width="100%">
       <Box display="flex" flexDirection="row">
@@ -60,6 +126,14 @@ function MonsterSenses({
             }
           />
         </div>
+        {hasBlind && (
+          <TextField
+            name="blindsight"
+            label="Blindsight"
+            value={blindsight}
+            onChange={handleIntChange}
+          />
+        )}
       </Box>
       <Box display="flex" flexDirection="row">
         <div className={classes.senseToggle}>
@@ -74,6 +148,14 @@ function MonsterSenses({
             }
           />
         </div>
+        {hasDark && (
+          <TextField
+            name="darkvision"
+            label="Darkvision"
+            value={darkvision}
+            onChange={handleIntChange}
+          />
+        )}
       </Box>
       <Box display="flex" flexDirection="row">
         <div className={classes.senseToggle}>
@@ -88,6 +170,14 @@ function MonsterSenses({
             }
           />
         </div>
+        {hasTremor && (
+          <TextField
+            name="tremorsense"
+            label="Tremorsense"
+            value={tremorsense}
+            onChange={handleIntChange}
+          />
+        )}
       </Box>
       <Box display="flex" flexDirection="row">
         <div className={classes.senseToggle}>
@@ -102,6 +192,14 @@ function MonsterSenses({
             }
           />
         </div>
+        {hasTruesight && (
+          <TextField
+            name="truesight"
+            label="Truesight"
+            value={truesight}
+            onChange={handleIntChange}
+          />
+        )}
       </Box>
     </Box>
   );

--- a/src/components/monster/monster-speed/MonsterSpeed.tsx
+++ b/src/components/monster/monster-speed/MonsterSpeed.tsx
@@ -175,7 +175,6 @@ function MonsterSpeed({
           />
         )}
       </Box>
-
       <Box display="flex" flexDirection="row">
         <div className={classes.speedToggle}>
           <FormControlLabel

--- a/src/components/monster/stat-block/StatBlock.tsx
+++ b/src/components/monster/stat-block/StatBlock.tsx
@@ -71,6 +71,9 @@ function StatBlock({ monster, classes }: InferProps<typeof StatBlock.propTypes>)
     return 10 + getProfModifier('per', monster);
   };
 
+  /**
+   * Handles displaying what senses are being outputted to the stat block
+   */
   const displaySenses = () => {
     if (
       !monster.blindsight.length &&

--- a/src/components/monster/stat-block/StatBlock.tsx
+++ b/src/components/monster/stat-block/StatBlock.tsx
@@ -62,6 +62,15 @@ const useStyles = () =>
   });
 
 function StatBlock({ monster, classes }: InferProps<typeof StatBlock.propTypes>) {
+  /**
+   * Calculates the passive perception. This is calculated from
+   * 10 + proficiency bonus + perception.
+   * https://roll20.net/compendium/dnd5e/Ability%20Scores#toc_8
+   */
+  const getPassiverPer = () => {
+    return 10 + getProfModifier('per', monster);
+  };
+
   const displaySenses = () => {
     if (
       !monster.blindsight.length &&
@@ -69,6 +78,16 @@ function StatBlock({ monster, classes }: InferProps<typeof StatBlock.propTypes>)
       !monster.tremorsense.length &&
       !monster.truesight.length
     ) {
+      // If we have a proficiency
+      if (monster.proficiencies.includes('per')) {
+        return (
+          <>
+            <strong>Senses:</strong> passive Perception {getPassiverPer()}
+          </>
+        );
+      }
+
+      // If we aren't proficient in perception return nothing for senses
       return <></>;
     }
 
@@ -86,6 +105,9 @@ function StatBlock({ monster, classes }: InferProps<typeof StatBlock.propTypes>)
             <>Tremorsense {monster.tremorsense}ft., </>
           )}
           {monster.truesight.length > 0 && <>Truesight {monster.truesight}ft., </>}
+          {monster.proficiencies.includes('per') && (
+            <>passive Perception {getPassiverPer()}</>
+          )}
         </span>
       </div>
     );

--- a/src/components/monster/stat-block/StatBlock.tsx
+++ b/src/components/monster/stat-block/StatBlock.tsx
@@ -250,13 +250,13 @@ function StatBlock({ monster, classes }: InferProps<typeof StatBlock.propTypes>)
                 </span>
               </div>
             )}
-            {monster.senses.length > 0 && (
+            {/* {monster.senses.length > 0 && (
               <div>
                 <span>
                   <strong>Senses</strong> {monster.senses.join(', ')}
                 </span>
               </div>
-            )}
+            )} */}
             <div>
               <span>
                 <strong>Languages</strong>{' '}

--- a/src/components/monster/stat-block/StatBlock.tsx
+++ b/src/components/monster/stat-block/StatBlock.tsx
@@ -264,13 +264,6 @@ function StatBlock({ monster, classes }: InferProps<typeof StatBlock.propTypes>)
               </div>
             )}
             {displaySenses()}
-            {/* {monster.senses.length > 0 && (
-              <div>
-                <span>
-                  <strong>Senses</strong> {monster.senses.join(', ')}
-                </span>
-              </div>
-            )} */}
             <div>
               <span>
                 <strong>Languages</strong>{' '}
@@ -325,6 +318,12 @@ function StatBlock({ monster, classes }: InferProps<typeof StatBlock.propTypes>)
                 Legendary Actions
               </div>
               <hr className={classes.titleUnderline} />
+              <p style={{ fontSize: '13px' }}>
+                {monster.name} can take 3 Legendary Actions, choosing from the
+                options below. Only one legendary action can be used at a time, and
+                only at the end of another creature's turn. Spent legendary Actions
+                are regained at the start of each turn.
+              </p>
               {monster.legenActions.map((action: MonsterAction) => (
                 <FormattedAction key={`formatted-${action.id}`} action={action} />
               ))}

--- a/src/components/monster/stat-block/StatBlock.tsx
+++ b/src/components/monster/stat-block/StatBlock.tsx
@@ -64,42 +64,6 @@ const useStyles = () =>
   });
 
 function StatBlock({ monster, classes }: InferProps<typeof StatBlock.propTypes>) {
-  const ref = useRef();
-
-  const exportImage = () => {
-    // The below needs to be here otherwise html2canvas can't handle svgs
-    // https://stackoverflow.com/questions/32481054/svg-not-displayed-when-using-html2canvas
-    var svgElements = document.body.querySelectorAll('svg');
-    svgElements.forEach(function (item) {
-      item.setAttribute('width', `${item.getBoundingClientRect().width}`);
-      item.setAttribute('height', `${item.getBoundingClientRect().height}`);
-      item.style.width = null;
-      item.style.height = null;
-    });
-
-    const element: any = ReactDOM.findDOMNode(ref.current);
-
-    return html2canvas(element, {
-      backgroundColor: null,
-      useCORS: true,
-    }).then((canvas) => {
-      const fileName: string = `${monster.name}.png`;
-      const uri: string = canvas.toDataURL('image/png', 1.0);
-
-      const link = document.createElement('a');
-
-      if (typeof link.download === 'string') {
-        link.href = uri;
-        link.download = fileName;
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-      } else {
-        window.open(uri);
-      }
-    });
-  };
-
   return (
     <div
       style={{
@@ -109,7 +73,7 @@ function StatBlock({ monster, classes }: InferProps<typeof StatBlock.propTypes>)
       }}
       className={classes.root}
     >
-      <div ref={ref}>
+      <div>
         <StatBlockBorder />
         <div className={classes.column}>
           <div className={`${classes.name} ${classes.accentColour}`}>

--- a/src/components/monster/stat-block/StatBlock.tsx
+++ b/src/components/monster/stat-block/StatBlock.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React from 'react';
 import PropTypes, { InferProps } from 'prop-types';
 import { withStyles, createStyles, Box } from '@material-ui/core';
 import SectionSeparator from './SectionSeparator';
@@ -11,8 +11,6 @@ import { getProfModifier } from '../../../hooks/getProfModifier';
 import FormattedAction from './FormattedAction';
 import MonsterAbility from '../../../models/MonsterAbility';
 import MonsterAction from '../../../models/MonsterAction';
-import ReactDOM from 'react-dom';
-import html2canvas from 'html2canvas';
 
 const useStyles = () =>
   createStyles({
@@ -64,6 +62,35 @@ const useStyles = () =>
   });
 
 function StatBlock({ monster, classes }: InferProps<typeof StatBlock.propTypes>) {
+  const displaySenses = () => {
+    if (
+      !monster.blindsight.length &&
+      !monster.darkvision.length &&
+      !monster.tremorsense.length &&
+      !monster.truesight.length
+    ) {
+      return <></>;
+    }
+
+    return (
+      <div>
+        <span>
+          <strong>Senses:</strong>{' '}
+          {monster.blindsight.length > 0 && (
+            <>Blindsight {monster.blindsight}ft., </>
+          )}
+          {monster.darkvision.length > 0 && (
+            <>Darkvision {monster.darkvision}ft., </>
+          )}
+          {monster.tremorsense.length > 0 && (
+            <>Tremorsense {monster.tremorsense}ft., </>
+          )}
+          {monster.truesight.length > 0 && <>Truesight {monster.truesight}ft., </>}
+        </span>
+      </div>
+    );
+  };
+
   return (
     <div
       style={{
@@ -214,6 +241,7 @@ function StatBlock({ monster, classes }: InferProps<typeof StatBlock.propTypes>)
                 </span>
               </div>
             )}
+            {displaySenses()}
             {/* {monster.senses.length > 0 && (
               <div>
                 <span>

--- a/src/models/MonsterDefinition.tsx
+++ b/src/models/MonsterDefinition.tsx
@@ -29,6 +29,10 @@ export default class MonsterDefinition {
   int: string = '0';
   wis: string = '0';
   chr: string = '0';
+  blindsight: string = '';
+  darkvision: string = '';
+  tremorsense: string = '';
+  truesight: string = '';
   profBonus: string = '0';
   challengeRating: string = '';
   rewardXP: string = '';
@@ -38,7 +42,6 @@ export default class MonsterDefinition {
   condImmunities: Array<string> = new Array<string>();
   resistances: Array<string> = new Array<string>();
   weaknesses: Array<string> = new Array<string>();
-  senses: Array<string> = new Array<string>();
   languages: Array<string> = new Array<string>();
   abilities: Array<MonsterAbility> = new Array<MonsterAbility>();
   actions: Array<MonsterAction> = new Array<MonsterAction>();


### PR DESCRIPTION
**Misc**
- Updated Version to 0.3.0
- Updated Readme for new release after this PR
- Fixed issue where the image may be cutoff when exporting

**Monster**
- Added truesight, darkvision, tremorsense, blindsight in lieu of the senses array that allows the user to put the effective range of the sense.
- Updated expansion panel titles to better describe and reflect what is in the individual panels
- Added senses panel

**Monster Senses**
- Added monster senses, works similar to how the speeds work with a toggle that allows you to edit individual senses

**Monster Properties**
- Removed the senses select from the component
- Styled bottom row to reflect the removing of the senses dropdown

**Stat Block**
- Calculates passive perception and puts it into senses if there is a proficiency in perception
- Senses now gets built off the new component
- Legendary Actions now has a summary like in the standard legendary actions sections in the Monster Manual.
