### PR TITLE
Added 2 columns to the stat block, now can be viewed on mobile devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ Currently can be found at: https://tjcowx.github.io/5e-homebrew-monsters/
 
 ## VERSIONS
 
+### 0.3.1 (2020-10-8)
+
+- Added a new feature. This allows the stat block to be toggled with two columns if 1 is too long for you
+- The app is now mobile responsive. This means it is no longer hard to use on a smaller screen.
+
 ### 0.3.0 (2020-10-06)
 
 - Added Passive perception into the stat block. This only shows up if the monster is proficient in perception

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "5e-homebrew-monsters",
   "homepage": "https://tjcowx.github.io/5e-homebrew-monsters/",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.10.2",

--- a/src/components/monster/Monster.tsx
+++ b/src/components/monster/Monster.tsx
@@ -63,6 +63,24 @@ const styles = (theme: Theme) => ({
     paddingLeft: theme.spacing(1),
     'overflow-x': 'auto',
   },
+  actionContainer: {
+    width: '100%',
+    display: 'flex',
+    justifyContent: 'space-between',
+    'flex-direction': 'row',
+    marginTop: '8px',
+    '@media (max-width: 600px)': {
+      display: 'inline-block',
+    },
+  },
+  statBlockActionContainer: {
+    justifyContent: 'flex-end',
+    display: 'flex',
+    '@media (max-width: 600px)': {
+      justifyContent: 'space-between',
+      width: '100%',
+    },
+  },
 });
 
 function Monster({ classes }: InferProps<typeof Monster.propTypes>) {
@@ -532,12 +550,8 @@ function Monster({ classes }: InferProps<typeof Monster.propTypes>) {
             />
           </ExpansionPanelDetails>
         </ExpansionPanel>
-        <Box
-          display="flex"
-          justifyContent="space-between"
-          flexDirection="row"
-          marginTop="8px"
-        >
+
+        <Box className={classes.actionContainer}>
           <Box justifyContent="flex-start" display="flex">
             <Button
               color="primary"
@@ -548,7 +562,7 @@ function Monster({ classes }: InferProps<typeof Monster.propTypes>) {
               Example
             </Button>
           </Box>
-          <Box justifyContent="flex-end" display="flex">
+          <Box className={classes.statBlockActionContainer}>
             <FormControlLabel
               label="Toggle Columns"
               control={

--- a/src/components/monster/Monster.tsx
+++ b/src/components/monster/Monster.tsx
@@ -21,6 +21,8 @@ import {
   withStyles,
   Button,
   Box,
+  FormControlLabel,
+  Switch,
 } from '@material-ui/core';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import MonsterAbility from '../../models/MonsterAbility';
@@ -57,6 +59,7 @@ const styles = (theme: Theme) => ({
 
 function Monster({ classes }: InferProps<typeof Monster.propTypes>) {
   const [monster, setMonster] = useState(new MonsterDefinition());
+  const [twoCols, setTwoCols] = useState(false);
 
   const componentRef = useRef();
 
@@ -536,6 +539,16 @@ function Monster({ classes }: InferProps<typeof Monster.propTypes>) {
             >
               Load Example
             </Button>
+            <FormControlLabel
+              label="Two Columns"
+              control={
+                <Switch
+                  color="primary"
+                  checked={twoCols}
+                  onChange={() => setTwoCols(!twoCols)}
+                />
+              }
+            />
           </Box>
           <Box justifyContent="flex-end" display="flex">
             <input
@@ -572,7 +585,7 @@ function Monster({ classes }: InferProps<typeof Monster.propTypes>) {
         </Box>
       </Box>
       <div className={classes.statBlockContainer} ref={componentRef}>
-        <StatBlock monster={monster} />
+        <StatBlock monster={monster} twoColumns={twoCols} />
       </div>
     </Box>
   );

--- a/src/components/monster/Monster.tsx
+++ b/src/components/monster/Monster.tsx
@@ -37,7 +37,10 @@ import html2canvas from 'html2canvas';
 const styles = (theme: Theme) => ({
   root: {
     width: '100%',
-    display: 'flex',
+    display: 'inline-block',
+    '@media (min-width: 1024px)': {
+      display: 'flex',
+    },
   },
   heading: {
     fontSize: theme.typography.pxToRem(15),
@@ -49,7 +52,11 @@ const styles = (theme: Theme) => ({
     color: theme.palette.text.secondary,
   },
   monsterContainer: {
-    width: '50%',
+    width: '100%',
+    '@media (min-width: 1024px)': {
+      backgroundColor: 'red',
+      minWidth: '50%',
+    },
     paddingRight: theme.spacing(1),
   },
   statBlockContainer: {
@@ -537,10 +544,12 @@ function Monster({ classes }: InferProps<typeof Monster.propTypes>) {
               aria-label="Load Example"
               onClick={generateExample}
             >
-              Load Example
+              Example
             </Button>
+          </Box>
+          <Box justifyContent="flex-end" display="flex">
             <FormControlLabel
-              label="Two Columns"
+              label="Toggle Columns"
               control={
                 <Switch
                   color="primary"
@@ -549,29 +558,6 @@ function Monster({ classes }: InferProps<typeof Monster.propTypes>) {
                 />
               }
             />
-          </Box>
-          <Box justifyContent="flex-end" display="flex">
-            <input
-              onChange={importConfig}
-              accept="application/JSON"
-              style={{ display: 'none' }}
-              id="config-upload"
-              type="file"
-            />
-            <label htmlFor="config-upload">
-              <Button variant="contained" component="span" color="primary">
-                Import
-              </Button>
-            </label>
-            <Button
-              color="primary"
-              variant="contained"
-              aria-label="Export"
-              style={{ marginLeft: '8px' }}
-              onClick={exportConfig}
-            >
-              Export
-            </Button>
             <Button
               color="primary"
               variant="contained"
@@ -579,9 +565,32 @@ function Monster({ classes }: InferProps<typeof Monster.propTypes>) {
               style={{ marginLeft: '8px' }}
               onClick={exportImage}
             >
-              Save as Image
+              Save Image
             </Button>
           </Box>
+        </Box>
+        <Box style={{ paddingTop: '8px' }}>
+          <input
+            onChange={importConfig}
+            accept="application/JSON"
+            style={{ display: 'none' }}
+            id="config-upload"
+            type="file"
+          />
+          <label htmlFor="config-upload">
+            <Button variant="contained" component="span" color="primary">
+              Import
+            </Button>
+          </label>
+          <Button
+            color="primary"
+            variant="contained"
+            aria-label="Export"
+            style={{ marginLeft: '8px' }}
+            onClick={exportConfig}
+          >
+            Export
+          </Button>
         </Box>
       </Box>
       <div className={classes.statBlockContainer} ref={componentRef}>

--- a/src/components/monster/Monster.tsx
+++ b/src/components/monster/Monster.tsx
@@ -4,7 +4,7 @@
  * properties in an expansion panel.
  */
 
-import React, { MutableRefObject, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import MonsterStats from './monster-stats/MonsterStats';
 import MonsterProperties from './monster-properties/MonsterProperties';
 import MonsterActions from './monster-actions/MonsterActions';

--- a/src/components/monster/Monster.tsx
+++ b/src/components/monster/Monster.tsx
@@ -4,7 +4,7 @@
  * properties in an expansion panel.
  */
 
-import React, { useRef, useState } from 'react';
+import React, { MutableRefObject, useRef, useState } from 'react';
 import MonsterStats from './monster-stats/MonsterStats';
 import MonsterProperties from './monster-properties/MonsterProperties';
 import MonsterActions from './monster-actions/MonsterActions';
@@ -54,13 +54,14 @@ const styles = (theme: Theme) => ({
   monsterContainer: {
     width: '100%',
     '@media (min-width: 1024px)': {
-      backgroundColor: 'red',
       minWidth: '50%',
+      maxWidth: '50%',
     },
     paddingRight: theme.spacing(1),
   },
   statBlockContainer: {
     paddingLeft: theme.spacing(1),
+    'overflow-x': 'auto',
   },
 });
 
@@ -593,8 +594,8 @@ function Monster({ classes }: InferProps<typeof Monster.propTypes>) {
           </Button>
         </Box>
       </Box>
-      <div className={classes.statBlockContainer} ref={componentRef}>
-        <StatBlock monster={monster} twoColumns={twoCols} />
+      <div className={classes.statBlockContainer}>
+        <StatBlock monster={monster} twoColumns={twoCols} saveRef={componentRef} />
       </div>
     </Box>
   );

--- a/src/components/monster/monster-abilities/AddMonsterAbility.tsx
+++ b/src/components/monster/monster-abilities/AddMonsterAbility.tsx
@@ -8,12 +8,43 @@ import PropTypes, { InferProps } from 'prop-types';
 import MonsterAbility from '../../../models/MonsterAbility';
 
 const useStyles = (theme: Theme) => ({
+  root: {
+    display: 'flex',
+    'flex-direction': 'row',
+    width: '100%',
+    justifyContent: 'space-between',
+    '@media (max-width: 767px)': {
+      display: 'inline-block',
+    },
+  },
   inputField: {
     display: 'flex',
     margin: theme.spacing(1),
   },
+  nameWrapper: {
+    width: '40%',
+    '@media (max-width: 767px)': {
+      width: '100%',
+    },
+  },
+  descriptionWrapper: {
+    width: '65%',
+    '@media (max-width: 767px)': {
+      width: '100%',
+    },
+  },
+  actionWrapper: {
+    width: '15%',
+    minWidth: '150px',
+    '@media (max-width: 767px)': {
+      width: '100%',
+    },
+  },
   saveButton: {
     marginLeft: 'auto',
+    '@media (max-width: 767px)': {
+      display: 'inline-block',
+    },
   },
 });
 
@@ -74,13 +105,8 @@ function AddMonsterAbility({
 
   return (
     <>
-      <Box
-        display="flex"
-        flexDirection="row"
-        width="100%"
-        justifyContent="space-between"
-      >
-        <Box width="25%">
+      <Box className={classes.root}>
+        <Box className={classes.nameWrapper} width="25%">
           <TextField
             label="Name"
             aria-label="Ability Name"
@@ -90,7 +116,7 @@ function AddMonsterAbility({
             className={classes.inputField}
           />
         </Box>
-        <Box width="60%">
+        <Box className={classes.descriptionWrapper} width="60%">
           <TextField
             multiline
             label="Description"
@@ -102,7 +128,7 @@ function AddMonsterAbility({
           />
         </Box>
         <Box
-          width="15%"
+          className={classes.actionWrapper}
           justifyContent="flex-end"
           display="flex"
           alignItems="center"

--- a/src/components/monster/monster-abilities/MonsterAbilityListItem.tsx
+++ b/src/components/monster/monster-abilities/MonsterAbilityListItem.tsx
@@ -20,6 +20,7 @@ export default function MonsterAbilityListItem({
     <>
       <ListItem>
         <ListItemText
+          style={{ paddingRight: '96px' }}
           primary={ability.name}
           secondary={ability.description}
         ></ListItemText>

--- a/src/components/monster/monster-actions/AddMonsterAction.tsx
+++ b/src/components/monster/monster-actions/AddMonsterAction.tsx
@@ -23,6 +23,77 @@ import { getDamageTypes } from '../../../hooks/getDamageTypes';
 
 const useStyles = (theme: Theme) => ({
   inputField: { display: 'flex', margin: theme.spacing(1) },
+  topRowContainer: {
+    display: 'flex',
+    'flex-direction': 'row',
+    width: '100%',
+    '@media (max-width: 767px)': {
+      display: 'inline-block',
+    },
+  },
+  nameTypeContainer: {
+    display: 'flex',
+    'flex-direction': 'row',
+    width: '66%',
+    '@media (max-width: 767px)': {
+      width: '100%',
+    },
+  },
+  isAttack: {
+    width: '33%',
+    margin: theme.spacing(1),
+    '@media (max-width: 767px)': {
+      width: '100%',
+      margin: '0',
+      marginTop: '8px',
+    },
+  },
+  attackRowContainer: {
+    display: 'flex',
+    'flex-direction': 'row',
+    width: '100%',
+    '@media (max-width: 767px)': {
+      display: 'inline-block',
+    },
+  },
+  attackTypeWrapper: {
+    width: '33%',
+    '@media (max-width: 767px)': {
+      width: '100%',
+    },
+  },
+  attackStatContainer: {
+    display: 'flex',
+    width: '66%',
+    '@media (max-width: 767px)': {
+      width: '100%',
+    },
+  },
+  bottomRowContainer: {
+    display: 'flex',
+    'flex-direction': 'row',
+    width: '100%',
+    '@media (max-width: 767px)': {
+      display: 'inline-block',
+    },
+  },
+  descriptionWrapper: {
+    width: '85%',
+    '@media (max-width: 767px)': {
+      width: '100%',
+    },
+  },
+  actionContainer: {
+    width: '15%',
+    minWidth: '150px',
+    justifyContent: 'flex-end',
+    display: 'flex',
+    alignItems: 'center',
+    '@media (max-width: 767px)': {
+      marginTop: '8px',
+      width: '100%',
+    },
+  },
 });
 
 function AddMonsterAction({
@@ -125,33 +196,35 @@ function AddMonsterAction({
 
   return (
     <>
-      <Box display="flex" flexDirection="row" width="100%">
-        <TextField
-          label="Name"
-          aria-label="Action Name"
-          name="name"
-          className={classes.inputField}
-          value={action.name}
-          style={{ width: '33%' }}
-          onChange={handleChange}
-        />
-        <FormControl className={classes.inputField} style={{ width: '33%' }}>
-          <InputLabel id="action-type-label" aria-label="Action Type">
-            Type
-          </InputLabel>
-          <Select
-            name="actionType"
-            labelId="action-type-label"
-            value={action.actionType}
+      <Box className={classes.topRowContainer}>
+        <Box className={classes.nameTypeContainer}>
+          <TextField
+            label="Name"
+            aria-label="Action Name"
+            name="name"
+            className={classes.inputField}
+            value={action.name}
+            style={{ width: '50%' }}
             onChange={handleChange}
-          >
-            {actionTypes.map((actionType: string) => (
-              <MenuItem key={actionType} value={actionType}>
-                {actionType}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
+          />
+          <FormControl className={classes.inputField} style={{ width: '50%' }}>
+            <InputLabel id="action-type-label" aria-label="Action Type">
+              Type
+            </InputLabel>
+            <Select
+              name="actionType"
+              labelId="action-type-label"
+              value={action.actionType}
+              onChange={handleChange}
+            >
+              {actionTypes.map((actionType: string) => (
+                <MenuItem key={actionType} value={actionType}>
+                  {actionType}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Box>
         <FormControlLabel
           label="Is Attack"
           aria-label="Is Attack Action"
@@ -163,48 +236,51 @@ function AddMonsterAction({
               color="primary"
             />
           }
-          className={classes.inputField}
-          style={{ width: '33%' }}
+          className={`${classes.inputField} ${classes.isAttack}`}
         />
       </Box>
       {action.isAttack && (
         <>
-          <Box display="flex" flexDirection="row" width="100%">
-            <FormControl className={classes.inputField} style={{ width: '33%' }}>
-              <InputLabel id="attack-type-label" aria-label="Attack Type">
-                Attack Type
-              </InputLabel>
-              <Select
-                name="attackType"
-                labelId="attack-type-label"
-                value={action.attackType}
+          <Box className={classes.attackRowContainer}>
+            <Box className={classes.attackTypeWrapper}>
+              <FormControl className={classes.inputField}>
+                <InputLabel id="attack-type-label" aria-label="Attack Type">
+                  Attack Type
+                </InputLabel>
+                <Select
+                  name="attackType"
+                  labelId="attack-type-label"
+                  value={action.attackType}
+                  onChange={handleChange}
+                >
+                  {attackTypes.map((attackType: string) => (
+                    <MenuItem key={attackType} value={attackType}>
+                      {attackType}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Box>
+            <Box className={classes.attackStatContainer}>
+              <TextField
+                name="reach"
+                label="Reach"
+                aria-label="React"
+                value={action.reach}
                 onChange={handleChange}
-              >
-                {attackTypes.map((attackType: string) => (
-                  <MenuItem key={attackType} value={attackType}>
-                    {attackType}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-            <TextField
-              name="reach"
-              label="Reach"
-              aria-label="React"
-              value={action.reach}
-              onChange={handleChange}
-              className={classes.inputField}
-              style={{ width: '33%' }}
-            />
-            <TextField
-              name="toHit"
-              label="To Hit"
-              aria-label="To Hit"
-              value={action.toHit}
-              onChange={handleChange}
-              className={classes.inputField}
-              style={{ width: '33%' }}
-            />
+                className={classes.inputField}
+                style={{ width: '50%' }}
+              />
+              <TextField
+                name="toHit"
+                label="To Hit"
+                aria-label="To Hit"
+                value={action.toHit}
+                onChange={handleChange}
+                className={classes.inputField}
+                style={{ width: '50%' }}
+              />
+            </Box>
           </Box>
           <Box display="flex" flexDirection="row" width="100%">
             <TextField
@@ -236,22 +312,19 @@ function AddMonsterAction({
           </Box>
         </>
       )}
-      <Box display="flex" flexDirection="row" width="100%">
-        <TextField
-          className={classes.inputField}
-          style={{ width: '85%' }}
-          label="Description"
-          aria-label="Action Description"
-          name="description"
-          value={action.description}
-          onChange={handleChange}
-        />
-        <Box
-          width="15%"
-          justifyContent="flex-end"
-          display="flex"
-          alignItems="center"
-        >
+      <Box className={classes.bottomRowContainer}>
+        <Box className={classes.descriptionWrapper}>
+          <TextField
+            multiline
+            className={classes.inputField}
+            label="Description"
+            aria-label="Action Description"
+            name="description"
+            value={action.description}
+            onChange={handleChange}
+          />
+        </Box>
+        <Box className={classes.actionContainer}>
           <Button
             color="primary"
             variant="contained"

--- a/src/components/monster/monster-actions/MonsterActionListItem.tsx
+++ b/src/components/monster/monster-actions/MonsterActionListItem.tsx
@@ -13,13 +13,14 @@ import PropTypes, { InferProps } from 'prop-types';
 
 function MonsterActionListItem({
   action,
+  actionType,
   removeAction,
   editAction,
 }: InferProps<typeof MonsterActionListItem.propTypes>) {
   const [actionSummary, setActionSummary] = useState('');
 
   useEffect(() => {
-    let summary: string = `${action.actionType} -`;
+    let summary: string = `${actionType} -`;
     if (action.attackType != null) {
       summary += ` ${action.attackType} Attack: ${action.toHit} to hit, reach ${action.reach}`;
       summary += `, Hit: ${action.damage} ${action.damageType} damage`;
@@ -60,6 +61,7 @@ function MonsterActionListItem({
 
 MonsterActionListItem.propTypes = {
   action: PropTypes.instanceOf(MonsterAction).isRequired,
+  actionType: PropTypes.string.isRequired,
   removeAction: PropTypes.func.isRequired,
   editAction: PropTypes.func.isRequired,
 };

--- a/src/components/monster/monster-actions/MonsterActionListItem.tsx
+++ b/src/components/monster/monster-actions/MonsterActionListItem.tsx
@@ -33,7 +33,11 @@ function MonsterActionListItem({
   return (
     <>
       <ListItem>
-        <ListItemText primary={action.name} secondary={actionSummary}></ListItemText>
+        <ListItemText
+          primary={action.name}
+          secondary={actionSummary}
+          style={{ paddingRight: '96px' }}
+        ></ListItemText>
         <ListItemSecondaryAction>
           <IconButton
             aria-label="edit ability"

--- a/src/components/monster/monster-actions/MonsterActions.tsx
+++ b/src/components/monster/monster-actions/MonsterActions.tsx
@@ -24,7 +24,8 @@ function MonsterActions({
    * an existing one
    * @param action the action we are editting
    */
-  const editAction = (action: MonsterAction) => {
+  const editAction = (action: MonsterAction, actionType: string) => {
+    action.actionType = actionType;
     setEdittingAction(action);
   };
 

--- a/src/components/monster/monster-actions/MonsterActionsList.tsx
+++ b/src/components/monster/monster-actions/MonsterActionsList.tsx
@@ -32,7 +32,7 @@ function MonsterActionsList({
             action={action}
             actionType={'Action'}
             removeAction={removeAction}
-            editAction={editAction}
+            editAction={editAction.bind(this, action, 'Action')}
           />
         ))}
         {reactions.map((action: MonsterAction) => (
@@ -41,7 +41,7 @@ function MonsterActionsList({
             action={action}
             actionType={'Reaction'}
             removeAction={removeAction}
-            editAction={editAction}
+            editAction={editAction.bind(this, action, 'Reaction')}
           />
         ))}
         {legenActions.map((action: MonsterAction) => (
@@ -50,7 +50,7 @@ function MonsterActionsList({
             action={action}
             actionType={'Legendary Action'}
             removeAction={removeAction}
-            editAction={editAction}
+            editAction={editAction.bind(this, action, 'Legendary')}
           />
         ))}
         {lairActions.map((action: MonsterAction) => (
@@ -59,7 +59,7 @@ function MonsterActionsList({
             action={action}
             actionType={'Lair Action'}
             removeAction={removeAction}
-            editAction={editAction}
+            editAction={editAction.bind(this, action, 'Lair')}
           />
         ))}
       </List>

--- a/src/components/monster/monster-actions/MonsterActionsList.tsx
+++ b/src/components/monster/monster-actions/MonsterActionsList.tsx
@@ -30,6 +30,7 @@ function MonsterActionsList({
           <MonsterActionListItem
             key={action.id}
             action={action}
+            actionType={'Action'}
             removeAction={removeAction}
             editAction={editAction}
           />
@@ -38,6 +39,7 @@ function MonsterActionsList({
           <MonsterActionListItem
             key={action.id}
             action={action}
+            actionType={'Reaction'}
             removeAction={removeAction}
             editAction={editAction}
           />
@@ -46,6 +48,7 @@ function MonsterActionsList({
           <MonsterActionListItem
             key={action.id}
             action={action}
+            actionType={'Legendary Action'}
             removeAction={removeAction}
             editAction={editAction}
           />
@@ -54,6 +57,7 @@ function MonsterActionsList({
           <MonsterActionListItem
             key={action.id}
             action={action}
+            actionType={'Lair Action'}
             removeAction={removeAction}
             editAction={editAction}
           />

--- a/src/components/monster/monster-properties/MonsterProperties.tsx
+++ b/src/components/monster/monster-properties/MonsterProperties.tsx
@@ -64,16 +64,6 @@ function MonsterProperties({
   ];
 
   /**
-   * A list of available senses in 5e
-   */
-  const availableSenses: Array<string> = [
-    'Blindsight',
-    'Darkvision',
-    'Tremorsense',
-    'Truesight',
-  ];
-
-  /**
    * A list of available languages in 5e
    */
   const availableLanguages: Array<string> = [

--- a/src/components/monster/monster-properties/MonsterProperties.tsx
+++ b/src/components/monster/monster-properties/MonsterProperties.tsx
@@ -25,6 +25,34 @@ const useStyles = (theme: Theme) => ({
     display: 'flex',
     margin: theme.spacing(1),
   },
+  crWrapper: {
+    display: 'flex',
+    'flex-direction': 'row',
+    width: '66%',
+    '@media (max-width: 767px)': {
+      width: '100%',
+    },
+  },
+  rowWrapper: {
+    display: 'flex',
+    'flex-direction': 'row',
+    width: '100%',
+    '@media (max-width: 767px)': {
+      display: 'inline-block',
+    },
+  },
+  twoItemRow: {
+    width: '50%',
+    '@media (max-width: 767px)': {
+      width: '100%',
+    },
+  },
+  langField: {
+    width: '33%',
+    '@media (max-width: 767px)': {
+      width: '100%',
+    },
+  },
 });
 
 function MonsterProperties({
@@ -87,8 +115,8 @@ function MonsterProperties({
 
   return (
     <div className={classes.descriptionRoot}>
-      <Box display="flex" flexDirection="row">
-        <FormControl className={classes.inputField} style={{ width: '50%' }}>
+      <Box className={classes.rowWrapper}>
+        <FormControl className={`${classes.inputField} ${classes.twoItemRow}`}>
           <InputLabel id="immunities-label">Damage Immunities</InputLabel>
           <Select
             name="immunities"
@@ -104,7 +132,7 @@ function MonsterProperties({
             ))}
           </Select>
         </FormControl>
-        <FormControl className={classes.inputField} style={{ width: '50%' }}>
+        <FormControl className={`${classes.inputField} ${classes.twoItemRow}`}>
           <InputLabel id="condition-label">Condition Immunities</InputLabel>
           <Select
             name="condImmunities"
@@ -121,8 +149,8 @@ function MonsterProperties({
           </Select>
         </FormControl>
       </Box>
-      <Box display="flex" flexDirection="row">
-        <FormControl className={classes.inputField} style={{ width: '50%' }}>
+      <Box className={classes.rowWrapper}>
+        <FormControl className={`${classes.inputField} ${classes.twoItemRow}`}>
           <InputLabel id="resistances-label">Resistances</InputLabel>
           <Select
             name="resistances"
@@ -138,7 +166,7 @@ function MonsterProperties({
             ))}
           </Select>
         </FormControl>
-        <FormControl className={classes.inputField} style={{ width: '50%' }}>
+        <FormControl className={`${classes.inputField} ${classes.twoItemRow}`}>
           <InputLabel id="weaknesses-label">Weaknesses</InputLabel>
           <Select
             name="weaknesses"
@@ -155,8 +183,8 @@ function MonsterProperties({
           </Select>
         </FormControl>
       </Box>
-      <Box display="flex" flexDirection="row">
-        <FormControl className={classes.inputField} style={{ width: '33%' }}>
+      <Box className={classes.rowWrapper}>
+        <FormControl className={`${classes.inputField} ${classes.langField}`}>
           <InputLabel id="languages-label">Languages</InputLabel>
           <Select
             name="languages"
@@ -172,24 +200,26 @@ function MonsterProperties({
             ))}
           </Select>
         </FormControl>
-        <TextField
-          className={classes.inputField}
-          style={{ width: '33%' }}
-          id="standard-basic"
-          label="Challenge Rating"
-          name="challengeRating"
-          value={challengeRating}
-          onChange={handleChange}
-        />
-        <TextField
-          className={classes.inputField}
-          style={{ width: '33%' }}
-          id="standard-basic"
-          label="Reward XP"
-          name="rewardXP"
-          value={rewardXP}
-          onChange={handleChange}
-        />
+        <Box className={classes.crWrapper}>
+          <TextField
+            className={classes.inputField}
+            style={{ width: '50%' }}
+            id="standard-basic"
+            label="Challenge Rating"
+            name="challengeRating"
+            value={challengeRating}
+            onChange={handleChange}
+          />
+          <TextField
+            className={classes.inputField}
+            style={{ width: '50%' }}
+            id="standard-basic"
+            label="Reward XP"
+            name="rewardXP"
+            value={rewardXP}
+            onChange={handleChange}
+          />
+        </Box>
       </Box>
     </div>
   );

--- a/src/components/monster/monster-senses/MonsterSenses.tsx
+++ b/src/components/monster/monster-senses/MonsterSenses.tsx
@@ -10,7 +10,7 @@ import React, { useEffect, useState } from 'react';
 
 const useStyles = makeStyles(() => ({
   senseToggle: {
-    minWidth: '170px',
+    minWidth: '160px',
     paddingRight: '8px',
     marginTop: 'auto',
   },

--- a/src/components/monster/monster-stats/MonsterStats.tsx
+++ b/src/components/monster/monster-stats/MonsterStats.tsx
@@ -29,6 +29,57 @@ const useStyles = (theme: Theme) => ({
     display: 'flex',
     margin: theme.spacing(1),
   },
+  acField: {
+    width: '33%',
+    '@media (max-width: 767px)': {
+      width: '100%',
+    },
+  },
+  hpField: {
+    width: '50%',
+  },
+  hpWrapper: {
+    width: '66%',
+    display: 'flex',
+    'flex-direction': 'row',
+    '@media (max-width: 767px)': {
+      width: '100%',
+    },
+  },
+  baseStatWrapper: {
+    width: '100%',
+    display: 'flex',
+    'flex-direction': 'row',
+    '@media (max-width: 767px)': {
+      display: 'inline-block',
+    },
+  },
+  statField: {
+    width: '50%',
+    '@media (max-width: 767px)': {
+      width: '100%',
+    },
+  },
+  rowWrapper: {
+    width: '100%',
+    display: 'flex',
+    'flex-direction': 'row',
+    '@media (max-width: 767px)': {
+      display: 'inline-block',
+    },
+  },
+  profBonus: {
+    width: '20%',
+    '@media (max-width: 767px)': {
+      width: '100%',
+    },
+  },
+  bottomRowSelects: {
+    width: '40%',
+    '@media (max-width: 767px)': {
+      width: '100%',
+    },
+  },
 });
 
 function MonsterStats({
@@ -64,88 +115,92 @@ function MonsterStats({
 
   return (
     <div className={classes.descriptionRoot}>
-      <Box display="flex" flexDirection="row">
+      <Box className={classes.rowWrapper}>
         <TextField
-          style={{ width: '20%' }}
-          className={classes.inputField}
+          className={`${classes.inputField} ${classes.acField}`}
           value={armourClass}
           name="armourClass"
           label="Armour Class"
           onChange={handleIntChange}
         />
-        <TextField
-          style={{ width: '20%' }}
-          className={classes.inputField}
-          label="Hit Points"
-          value={hitPoints}
-          name="hitPoints"
-          onChange={handleIntChange}
-        />
-        <TextField
-          style={{ width: '20%' }}
-          className={classes.inputField}
-          label="Hit Die"
-          value={hitDie}
-          name="hitDie"
-          onChange={handleChange}
-        />
+        <Box className={classes.hpWrapper}>
+          <TextField
+            className={`${classes.inputField} ${classes.hpField}`}
+            label="Hit Points"
+            value={hitPoints}
+            name="hitPoints"
+            onChange={handleIntChange}
+          />
+          <TextField
+            className={`${classes.inputField} ${classes.hpField}`}
+            label="Hit Die"
+            value={hitDie}
+            name="hitDie"
+            onChange={handleChange}
+          />
+        </Box>
       </Box>
 
-      <Box display="flex" flexDirection="row">
-        <TextField
-          className={classes.inputField}
-          label="Strength"
-          value={str}
-          name="str"
-          onChange={handleIntChange}
-        />
-        <TextField
-          className={classes.inputField}
-          label="Dexerity"
-          value={dex}
-          name="dex"
-          onChange={handleIntChange}
-        />
-        <TextField
-          className={classes.inputField}
-          label="Constitution"
-          value={con}
-          name="con"
-          onChange={handleIntChange}
-        />
-        <TextField
-          className={classes.inputField}
-          label="Intelligence"
-          value={int}
-          name="int"
-          onChange={handleIntChange}
-        />
-        <TextField
-          className={classes.inputField}
-          label="Wisdom"
-          value={wis}
-          name="wis"
-          onChange={handleIntChange}
-        />
-        <TextField
-          className={classes.inputField}
-          label="Charisma"
-          value={chr}
-          name="chr"
-          onChange={handleIntChange}
-        />
+      <Box className={classes.baseStatWrapper}>
+        <Box display="flex" flexDirection="row">
+          <TextField
+            className={`${classes.inputField} ${classes.statField}`}
+            label="Strength"
+            value={str}
+            name="str"
+            onChange={handleIntChange}
+          />
+          <TextField
+            className={`${classes.inputField} ${classes.statField}`}
+            label="Dexerity"
+            value={dex}
+            name="dex"
+            onChange={handleIntChange}
+          />
+        </Box>
+        <Box display="flex" flexDirection="row">
+          <TextField
+            className={`${classes.inputField} ${classes.statField}`}
+            label="Constitution"
+            value={con}
+            name="con"
+            onChange={handleIntChange}
+          />
+          <TextField
+            className={`${classes.inputField} ${classes.statField}`}
+            label="Intelligence"
+            value={int}
+            name="int"
+            onChange={handleIntChange}
+          />
+        </Box>
+        <Box display="flex" flexDirection="row">
+          <TextField
+            className={`${classes.inputField} ${classes.statField}`}
+            label="Wisdom"
+            value={wis}
+            name="wis"
+            onChange={handleIntChange}
+          />
+          <TextField
+            className={`${classes.inputField} ${classes.statField}`}
+            label="Charisma"
+            value={chr}
+            name="chr"
+            onChange={handleIntChange}
+          />
+        </Box>
       </Box>
 
-      <Box display="flex" flexDirection="row">
+      <Box className={classes.rowWrapper}>
         <TextField
-          className={classes.inputField}
+          className={`${classes.profBonus} ${classes.inputField}`}
           label="Proficiency Bonus"
           value={profBonus}
           name="profBonus"
           onChange={handleIntChange}
-          style={{ width: '20%' }}
         />
-        <FormControl className={classes.inputField} style={{ width: '40%' }}>
+        <FormControl className={`${classes.bottomRowSelects} ${classes.inputField}`}>
           <InputLabel id="skillProf-label">Skill Proficiencies</InputLabel>
           <Select
             name="proficiencies"
@@ -164,7 +219,7 @@ function MonsterStats({
             })}
           </Select>
         </FormControl>
-        <FormControl className={classes.inputField} style={{ width: '40%' }}>
+        <FormControl className={`${classes.bottomRowSelects} ${classes.inputField}`}>
           <InputLabel id="savingThrows-label">Saving Throws</InputLabel>
           <Select
             name="savingThrows"

--- a/src/components/monster/stat-block/SectionSeparator.tsx
+++ b/src/components/monster/stat-block/SectionSeparator.tsx
@@ -4,10 +4,10 @@ function SectionSeparator() {
   return (
     <>
       <svg
-        width="450px"
+        width="600px"
         style={{ fill: '#99351f', stroke: '#99351f', height: '5px' }}
       >
-        <polyline points="0,0 450,2.5 0,5" />
+        <polyline points="0,0 600,2.5 0,5" />
       </svg>
     </>
   );

--- a/src/components/monster/stat-block/StatBlock.tsx
+++ b/src/components/monster/stat-block/StatBlock.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { MutableRefObject } from 'react';
 import PropTypes, { InferProps } from 'prop-types';
 import { withStyles, createStyles, Box } from '@material-ui/core';
 import SectionSeparator from './SectionSeparator';
@@ -16,17 +16,25 @@ const useStyles = () =>
   createStyles({
     root: {
       fontFamily: 'Arial, Helvetica, sans-serif',
+      paddingLeft: '16px',
+      paddingRight: '16px',
+      whiteSpace: 'pre-wrap',
+      '@media (max-width: 1024px)': {
+        padding: '16px 0',
+      },
     },
     accentColour: { color: '#58170D' },
     oneColumn: {
-      width: '600px',
       backgroundColor: '#fdf1dc',
       padding: '16px',
       marginLeft: '4px',
       marginRight: '4px',
+      margin: '0 auto',
+    },
+    wrapOneCol: {
+      width: '632px',
     },
     twoColumns: {
-      width: '1200px',
       columnGap: '32px',
       WebkitColumnCount: 2,
       MozColumnCount: 2,
@@ -35,6 +43,10 @@ const useStyles = () =>
       padding: '16px',
       marginLeft: '4px',
       marginRight: '4px',
+    },
+    wrapTwoCol: {
+      width: '1232px',
+      margin: '0 auto',
     },
     name: {
       fontFamily: 'Georgia, Serif',
@@ -79,6 +91,7 @@ const useStyles = () =>
 function StatBlock({
   monster,
   twoColumns,
+  saveRef,
   classes,
 }: InferProps<typeof StatBlock.propTypes>) {
   /**
@@ -136,15 +149,11 @@ function StatBlock({
   };
 
   return (
-    <div
-      style={{
-        paddingLeft: '16px',
-        paddingRight: '16px',
-        whiteSpace: 'pre-wrap',
-      }}
-      className={classes.root}
-    >
-      <div>
+    <div className={classes.root}>
+      <div
+        ref={saveRef}
+        className={`${twoColumns ? classes.wrapTwoCol : classes.wrapOneCol}`}
+      >
         <StatBlockBorder />
         <div className={`${twoColumns ? classes.twoColumns : classes.oneColumn}`}>
           <div className={`${classes.name} ${classes.accentColour}`}>
@@ -372,6 +381,7 @@ function StatBlock({
 StatBlock.propTypes = {
   monster: PropTypes.any.isRequired,
   twoColumns: PropTypes.bool.isRequired,
+  saveRef: PropTypes.any,
   classes: PropTypes.any,
 };
 

--- a/src/components/monster/stat-block/StatBlock.tsx
+++ b/src/components/monster/stat-block/StatBlock.tsx
@@ -1,4 +1,4 @@
-import React, { MutableRefObject } from 'react';
+import React from 'react';
 import PropTypes, { InferProps } from 'prop-types';
 import { withStyles, createStyles, Box } from '@material-ui/core';
 import SectionSeparator from './SectionSeparator';

--- a/src/components/monster/stat-block/StatBlock.tsx
+++ b/src/components/monster/stat-block/StatBlock.tsx
@@ -19,7 +19,7 @@ const useStyles = () =>
     },
     accentColour: { color: '#58170D' },
     column: {
-      width: '450px',
+      width: '600px',
       backgroundColor: '#fdf1dc',
       padding: '16px',
       marginLeft: '4px',

--- a/src/components/monster/stat-block/StatBlock.tsx
+++ b/src/components/monster/stat-block/StatBlock.tsx
@@ -18,8 +18,19 @@ const useStyles = () =>
       fontFamily: 'Arial, Helvetica, sans-serif',
     },
     accentColour: { color: '#58170D' },
-    column: {
+    oneColumn: {
       width: '600px',
+      backgroundColor: '#fdf1dc',
+      padding: '16px',
+      marginLeft: '4px',
+      marginRight: '4px',
+    },
+    twoColumns: {
+      width: '1200px',
+      columnGap: '32px',
+      WebkitColumnCount: 2,
+      MozColumnCount: 2,
+      columnCount: 2,
       backgroundColor: '#fdf1dc',
       padding: '16px',
       marginLeft: '4px',
@@ -39,6 +50,10 @@ const useStyles = () =>
     singleItemList: {
       fontSize: '14px',
       padding: '4px 0px',
+      display: 'inline-block',
+    },
+    actionContainer: {
+      display: 'inline-block',
     },
     stats: {
       fontSize: '15px',
@@ -61,7 +76,11 @@ const useStyles = () =>
     },
   });
 
-function StatBlock({ monster, classes }: InferProps<typeof StatBlock.propTypes>) {
+function StatBlock({
+  monster,
+  twoColumns,
+  classes,
+}: InferProps<typeof StatBlock.propTypes>) {
   /**
    * Calculates the passive perception. This is calculated from
    * 10 + proficiency bonus + perception.
@@ -127,7 +146,7 @@ function StatBlock({ monster, classes }: InferProps<typeof StatBlock.propTypes>)
     >
       <div>
         <StatBlockBorder />
-        <div className={classes.column}>
+        <div className={`${twoColumns ? classes.twoColumns : classes.oneColumn}`}>
           <div className={`${classes.name} ${classes.accentColour}`}>
             {monster.name}
           </div>
@@ -294,7 +313,7 @@ function StatBlock({ monster, classes }: InferProps<typeof StatBlock.propTypes>)
             })}
           </div>
           {monster.actions.length > 0 && (
-            <>
+            <div className={classes.actionContainer}>
               <div className={`${classes.actionTypeHeader} ${classes.accentColour}`}>
                 Actions
               </div>
@@ -302,7 +321,7 @@ function StatBlock({ monster, classes }: InferProps<typeof StatBlock.propTypes>)
               {monster.actions.map((action: MonsterAction) => (
                 <FormattedAction key={`formatted-${action.id}`} action={action} />
               ))}
-            </>
+            </div>
           )}
           {monster.reactions.length > 0 && (
             <>
@@ -352,6 +371,7 @@ function StatBlock({ monster, classes }: InferProps<typeof StatBlock.propTypes>)
 
 StatBlock.propTypes = {
   monster: PropTypes.any.isRequired,
+  twoColumns: PropTypes.bool.isRequired,
   classes: PropTypes.any,
 };
 

--- a/src/components/monster/stat-block/StatBlock.tsx
+++ b/src/components/monster/stat-block/StatBlock.tsx
@@ -333,7 +333,7 @@ function StatBlock({
             </div>
           )}
           {monster.reactions.length > 0 && (
-            <>
+            <div className={classes.actionContainer}>
               <div className={`${classes.actionTypeHeader} ${classes.accentColour}`}>
                 Reactions
               </div>
@@ -341,10 +341,10 @@ function StatBlock({
               {monster.reactions.map((action: MonsterAction) => (
                 <FormattedAction key={`formatted-${action.id}`} action={action} />
               ))}
-            </>
+            </div>
           )}
           {monster.legenActions.length > 0 && (
-            <>
+            <div className={classes.actionContainer}>
               <div className={`${classes.actionTypeHeader} ${classes.accentColour}`}>
                 Legendary Actions
               </div>
@@ -358,10 +358,10 @@ function StatBlock({
               {monster.legenActions.map((action: MonsterAction) => (
                 <FormattedAction key={`formatted-${action.id}`} action={action} />
               ))}
-            </>
+            </div>
           )}
           {monster.lairActions.length > 0 && (
-            <>
+            <div className={classes.actionContainer}>
               <div className={`${classes.actionTypeHeader} ${classes.accentColour}`}>
                 Lair Actions
               </div>
@@ -369,7 +369,7 @@ function StatBlock({
               {monster.lairActions.map((action: MonsterAction) => (
                 <FormattedAction key={`formatted-${action.id}`} action={action} />
               ))}
-            </>
+            </div>
           )}
         </div>
         <StatBlockBorder />


### PR DESCRIPTION
**Misc**
- Updated readme to show new changes
- Updated package version
- Entire app is now mobile responsive

**Monster**
- Moved the reference into the stat-block so the exported picture doesn't get aligned weird

**Monster Action**
- Fixed an issue where editing the action doesn't populate it's type dropdown
- Fixed an issue where long descriptions' text would show up behind the edit and the delete action in the list (this is also fixed in the abilities list)

**Stat Block**
- Now you can toggle two or one columns in the app.
