### PR TITLE
Restructured Props, Implemented Redux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "5e-homebrew-monsters",
-  "version": "0.2.2",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1437,6 +1437,24 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
     },
+    "@reduxjs/toolkit": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.4.0.tgz",
+      "integrity": "sha512-hkxQwVx4BNVRsYdxjNF6cAseRmtrkpSlcgJRr3kLUcHPIAMZAmMJkXmHh/eUEGTMqPzsYpJLM7NN2w9fxQDuGw==",
+      "requires": {
+        "immer": "^7.0.3",
+        "redux": "^4.0.0",
+        "redux-thunk": "^2.3.0",
+        "reselect": "^4.0.0"
+      },
+      "dependencies": {
+        "immer": {
+          "version": "7.0.9",
+          "resolved": "https://registry.npmjs.org/immer/-/immer-7.0.9.tgz",
+          "integrity": "sha512-Vs/gxoM4DqNAYR7pugIxi0Xc8XAun/uy7AQu4fLLqaTBHxjOP9pJ266Q9MWA/ly4z6rAFZbvViOtihxUZ7O28A=="
+        }
+      }
+    },
     "@sheerun/mutationobserver-shim": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz",
@@ -1743,6 +1761,16 @@
         "@types/node": "*"
       }
     },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@types/html-minifier-terser": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.0.tgz",
@@ -1922,6 +1950,18 @@
       "integrity": "sha512-ykkPQ+5nFknnlU6lDd947WbQ6TE3NNzbQAkInC2EKY1qeYdTKp7onFusmYZb+ityzx2YviqT6BXSu+LyWWJwcA==",
       "requires": {
         "@types/react": "*"
+      }
+    },
+    "@types/react-redux": {
+      "version": "7.1.9",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.9.tgz",
+      "integrity": "sha512-mpC0jqxhP4mhmOl3P4ipRsgTgbNofMRXJb08Ms6gekViLj61v1hOZEKWDCyWsdONr6EjEA6ZHXC446wdywDe0w==",
+      "dev": true,
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
       }
     },
     "@types/react-transition-group": {
@@ -11339,6 +11379,18 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "react-redux": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.1.tgz",
+      "integrity": "sha512-T+VfD/bvgGTUA74iW9d2i5THrDQWbweXP0AVNI8tNd1Rk5ch1rnMiJkDD67ejw7YBKM4+REvcvqRuWJb7BLuEg==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "hoist-non-react-statics": "^3.3.0",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.9.0"
+      }
+    },
     "react-scripts": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-3.4.1.tgz",
@@ -12380,6 +12432,20 @@
         "strip-indent": "^3.0.0"
       }
     },
+    "redux": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
+      "integrity": "sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "symbol-observable": "^1.2.0"
+      }
+    },
+    "redux-thunk": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
+      "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
+    },
     "regenerate": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.1.tgz",
@@ -12606,6 +12672,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "reselect": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
+      "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA=="
     },
     "resolve": {
       "version": "1.15.0",
@@ -13919,6 +13990,11 @@
         "unquote": "~1.1.1",
         "util.promisify": "~1.0.0"
       }
+    },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "symbol-tree": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@material-ui/core": "^4.10.2",
     "@material-ui/icons": "^4.9.1",
+    "@reduxjs/toolkit": "^1.4.0",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",
@@ -15,6 +16,7 @@
     "html2canvas": "^1.0.0-rc.7",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-redux": "^7.2.1",
     "react-scripts": "3.4.1",
     "uuid": "^8.3.0"
   },
@@ -47,6 +49,7 @@
     "@babel/preset-env": "^7.10.3",
     "@types/react": "^16.9.38",
     "@types/react-dom": "^16.9.8",
+    "@types/react-redux": "^7.1.9",
     "awesome-typescript-loader": "^5.2.1",
     "babel-loader": "^8.1.0",
     "css-loader": "^3.6.0",

--- a/src/components/monster/Monster.tsx
+++ b/src/components/monster/Monster.tsx
@@ -4,7 +4,7 @@
  * properties in an expansion panel.
  */
 
-import React, { useRef, useState } from 'react';
+import React, { ChangeEvent, useRef, useState } from 'react';
 import MonsterStats from './monster-stats/MonsterStats';
 import MonsterProperties from './monster-properties/MonsterProperties';
 import MonsterActions from './monster-actions/MonsterActions';
@@ -95,9 +95,7 @@ function Monster() {
    * Updates the state of the monster on a change.
    * @param event The material UI event
    */
-  const handleChange = (event: {
-    target: { name: any; value: any; valueAsNumber: boolean };
-  }) => {
+  const handleChange = (event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
     setMonster({
       ...monster,
       [event.target.name]: event.target.value,

--- a/src/components/monster/Monster.tsx
+++ b/src/components/monster/Monster.tsx
@@ -319,7 +319,6 @@ const Monster = connect(mapState, mapDispatch)(({custMonster, loadExample}: Prop
               size={custMonster.size}
               type={custMonster.type}
               alignment={custMonster.alignment}
-              handleChange={handleChange}
             />
           </ExpansionPanelDetails>
         </ExpansionPanel>

--- a/src/components/monster/Monster.tsx
+++ b/src/components/monster/Monster.tsx
@@ -27,9 +27,7 @@ import {
   createStyles,
 } from '@material-ui/core';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
-import MonsterAbility from '../../models/MonsterAbility';
-import MonsterAction from '../../models/MonsterAction';
-import MonsterDefinition, { MonsterType } from '../../models/MonsterDefinition';
+import { MonsterType } from '../../models/MonsterDefinition';
 import StatBlock from './stat-block/StatBlock';
 import { connect } from 'react-redux';
 import ReactDOM from 'react-dom';
@@ -91,7 +89,8 @@ const useStyles = makeStyles((theme: Theme) => createStyles({
 
 type Props = {
   custMonster: MonsterType,
-  loadExample: () => unknown
+  loadExample: () => unknown,
+  setMonsterFromObject: (newMonster: MonsterType) => unknown,
 }
 
 const mapState = (state: AppState) => ({
@@ -100,9 +99,10 @@ const mapState = (state: AppState) => ({
 
 const mapDispatch = (dispatch: Dispatch) => ({
   loadExample: () => dispatch(monster.actions.loadExample()),
+  setMonsterFromObject: (newMonster: MonsterType) => dispatch(monster.actions.setMonsterFromObject(newMonster)),
 })
 
-const Monster = connect(mapState, mapDispatch)(({custMonster, loadExample}: Props) => {
+const Monster = connect(mapState, mapDispatch)(({custMonster, loadExample, setMonsterFromObject}: Props) => {
   const [twoCols, setTwoCols] = useState(false);
 
   const componentRef = useRef();
@@ -110,136 +110,22 @@ const Monster = connect(mapState, mapDispatch)(({custMonster, loadExample}: Prop
   const classes = useStyles();
 
   /**
-   * Updates the state of the monster on a change.
-   * @param event The material UI event
-   */
-  const handleChange = (event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
-    // setMonster({
-    //   ...monster,
-    //   [event.target.name]: event.target.value,
-    // });
-  };
-
-  /**
-   * Updates an ability item if its id is already existing.
-   * If the id doesn't exist it will append the ability to the end
-   * @param updatedAbility The ability item to update or add
-   */
-  const updateMonsterAbilities = (updatedAbility: MonsterAbility) => {
-    // Check to see if we have an already existing ability item
-    const existingIndex: number = custMonster.abilities.findIndex(
-      (ability: MonsterAbility) => ability.id === updatedAbility.id
-    );
-
-    if (existingIndex > -1) {
-      // Copy the array so we don't have a chance to manipulate it before wanted
-      const abilities = [...custMonster.abilities];
-      // abilities[existingIndex] = new MonsterAbility(updatedAbility);
-
-      // setMonster({
-      //   ...monster,
-      //   abilities,
-      // });
-    } else {
-      // setMonster({
-      //   ...monster,
-      //   abilities: [...monster.abilities, new MonsterAbility(updatedAbility)],
-      // });
-    }
-  };
-
-  /**
-   * Removes an ability from the state that has the matching id
-   * @param id the id of the ability to remove
-   */
-  const removeAbility = (id: string) => {
-    // setMonster({
-    //   ...monster,
-    //   abilities: [
-    //     ...monster.abilities.filter((ability: MonsterAbility) => ability.id !== id),
-    //   ],
-    // });
-  };
-
-  /**
-   * Updates an action item if its id is already existing.
-   * If the id doesn't exist it will append the action to the end
-   * @param updatedActopm The action item to update or add
-   */
-  const updateMonsterActions = (updatedAction: MonsterAction) => {
-    // let actionsProperty: string = '';
-
-    // switch (updatedAction.actionType) {
-    //   case 'Action':
-    //     actionsProperty = 'actions';
-    //     break;
-    //   case 'Reaction':
-    //     actionsProperty = 'reactions';
-    //     break;
-    //   case 'Legendary':
-    //     actionsProperty = 'legenActions';
-    //     break;
-    //   case 'lair':
-    //     actionsProperty = 'lairActions';
-    //     break;
-    // }
-
-    // // Check to see if we have an already existing ability item
-    // const existingIndex: number = monster[`${actionsProperty}`].findIndex(
-    //   (action: MonsterAction) => action.id === updatedAction.id
-    // );
-
-    // if (existingIndex > -1) {
-    //   // Copy the array so we don't have a chance to manipulate it before wanted
-    //   const actions = [...monster[`${actionsProperty}`]];
-    //   actions[existingIndex] = new MonsterAction(updatedAction);
-
-    //   setMonster({
-    //     ...monster,
-    //     actions,
-    //   });
-    // } else {
-    //   setMonster({
-    //     ...monster,
-    //     [actionsProperty]: [
-    //       ...monster[`${actionsProperty}`],
-    //       new MonsterAction(updatedAction),
-    //     ],
-    //   });
-    // }
-  };
-
-  /**
-   * Removes an action from the state that has the matching id
-   * @param id the id of the ability to remove
-   */
-  const removeAction = (id: string, actionType: string) => {
-    // setMonster({
-    //   ...monster,
-    //   actions: [
-    //     ...monster.actions.filter((action: MonsterAction) => action.id !== id),
-    //   ],
-    // });
-  };
-
-  /**
    * Reads the file selected from the input, tries to make sure it's json
    * and sets it to the monster type
    */
-  const importConfig = ({ target }: any) => {
-    // const fileReader: FileReader = new FileReader();
+  const importConfig = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const fileReader: FileReader = new FileReader();
 
-    // fileReader.onload = (e) => {
-    //   try {
-    //     const importedObject: object = JSON.parse(e.target.result as string);
-    //     setMonster(new MonsterDefinition(importedObject));
-    //     alert('Monster Has Been Uploaded');
-    //   } catch (e) {
-    //     alert('Error parsing file');
-    //     console.error(e);
-    //   }
-    // };
-    // fileReader.readAsText(target.files[0]);
+    fileReader.onload = (e) => {
+      try {
+        setMonsterFromObject(JSON.parse(e.target.result as string) as MonsterType);
+        alert('Monster Has Been Uploaded');
+      } catch (e) {
+        alert('Error parsing file');
+        console.error(e);
+      }
+    };
+    fileReader.readAsText(event.target.files[0]);
   };
 
   /**

--- a/src/components/monster/Monster.tsx
+++ b/src/components/monster/Monster.tsx
@@ -416,9 +416,7 @@ const Monster = connect(mapState, mapDispatch)(({custMonster, loadExample}: Prop
             </Typography>
           </ExpansionPanelSummary>
           <ExpansionPanelDetails>
-            <MonsterAbilities
-              removeAbility={removeAbility}
-            />
+            <MonsterAbilities />
           </ExpansionPanelDetails>
         </ExpansionPanel>
 

--- a/src/components/monster/Monster.tsx
+++ b/src/components/monster/Monster.tsx
@@ -195,7 +195,7 @@ function Monster() {
    * Removes an action from the state that has the matching id
    * @param id the id of the ability to remove
    */
-  const removeAction = (id: string) => {
+  const removeAction = (id: string, actionType: string) => {
     setMonster({
       ...monster,
       actions: [

--- a/src/components/monster/Monster.tsx
+++ b/src/components/monster/Monster.tsx
@@ -18,7 +18,6 @@ import {
   ExpansionPanelDetails,
   Typography,
   Theme,
-  withStyles,
   Button,
   Box,
   FormControlLabel,

--- a/src/components/monster/Monster.tsx
+++ b/src/components/monster/Monster.tsx
@@ -381,7 +381,6 @@ const Monster = connect(mapState, mapDispatch)(({custMonster, loadExample}: Prop
               darkvision={custMonster.darkvision}
               tremorsense={custMonster.tremorsense}
               truesight={custMonster.truesight}
-              handleChange={handleChange}
             />
           </ExpansionPanelDetails>
         </ExpansionPanel>
@@ -402,7 +401,6 @@ const Monster = connect(mapState, mapDispatch)(({custMonster, loadExample}: Prop
               languages={custMonster.languages}
               challengeRating={custMonster.challengeRating}
               rewardXP={custMonster.rewardXP}
-              handleChange={handleChange}
             />
           </ExpansionPanelDetails>
         </ExpansionPanel>

--- a/src/components/monster/Monster.tsx
+++ b/src/components/monster/Monster.tsx
@@ -428,14 +428,7 @@ const Monster = connect(mapState, mapDispatch)(({custMonster, loadExample}: Prop
             </Typography>
           </ExpansionPanelSummary>
           <ExpansionPanelDetails>
-            <MonsterActions
-              actions={custMonster.actions}
-              legenActions={custMonster.legenActions}
-              lairActions={custMonster.lairActions}
-              reactions={custMonster.reactions}
-              addMonsterAction={updateMonsterActions}
-              removeAction={removeAction}
-            />
+            <MonsterActions />
           </ExpansionPanelDetails>
         </ExpansionPanel>
 

--- a/src/components/monster/Monster.tsx
+++ b/src/components/monster/Monster.tsx
@@ -5,6 +5,7 @@
  */
 
 import React, { ChangeEvent, useRef, useState } from 'react';
+import { Dispatch } from 'redux';
 import MonsterStats from './monster-stats/MonsterStats';
 import MonsterProperties from './monster-properties/MonsterProperties';
 import MonsterActions from './monster-actions/MonsterActions';
@@ -28,10 +29,15 @@ import {
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import MonsterAbility from '../../models/MonsterAbility';
 import MonsterAction from '../../models/MonsterAction';
-import MonsterDefinition from '../../models/MonsterDefinition';
+import MonsterDefinition, { MonsterType } from '../../models/MonsterDefinition';
 import StatBlock from './stat-block/StatBlock';
+import { connect } from 'react-redux';
 import ReactDOM from 'react-dom';
 import html2canvas from 'html2canvas';
+import { AppState } from '../../store/store';
+import { monsterSelector } from '../../selectors/monsterSelector';
+import monster from '../../reducers/monsterReducer';
+
 
 /** Setup the styles and theming for this component and children */
 const useStyles = makeStyles((theme: Theme) => createStyles({
@@ -83,8 +89,20 @@ const useStyles = makeStyles((theme: Theme) => createStyles({
   },
 }));
 
-function Monster() {
-  const [monster, setMonster] = useState(new MonsterDefinition());
+type Props = {
+  custMonster: MonsterType,
+  loadExample: () => unknown
+}
+
+const mapState = (state: AppState) => ({
+  custMonster: monsterSelector(state),
+})
+
+const mapDispatch = (dispatch: Dispatch) => ({
+  loadExample: () => dispatch(monster.actions.loadExample()),
+})
+
+const Monster = connect(mapState, mapDispatch)(({custMonster, loadExample}: Props) => {
   const [twoCols, setTwoCols] = useState(false);
 
   const componentRef = useRef();
@@ -96,10 +114,10 @@ function Monster() {
    * @param event The material UI event
    */
   const handleChange = (event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
-    setMonster({
-      ...monster,
-      [event.target.name]: event.target.value,
-    });
+    // setMonster({
+    //   ...monster,
+    //   [event.target.name]: event.target.value,
+    // });
   };
 
   /**
@@ -109,24 +127,24 @@ function Monster() {
    */
   const updateMonsterAbilities = (updatedAbility: MonsterAbility) => {
     // Check to see if we have an already existing ability item
-    const existingIndex: number = monster.abilities.findIndex(
+    const existingIndex: number = custMonster.abilities.findIndex(
       (ability: MonsterAbility) => ability.id === updatedAbility.id
     );
 
     if (existingIndex > -1) {
       // Copy the array so we don't have a chance to manipulate it before wanted
-      const abilities = [...monster.abilities];
-      abilities[existingIndex] = new MonsterAbility(updatedAbility);
+      const abilities = [...custMonster.abilities];
+      // abilities[existingIndex] = new MonsterAbility(updatedAbility);
 
-      setMonster({
-        ...monster,
-        abilities,
-      });
+      // setMonster({
+      //   ...monster,
+      //   abilities,
+      // });
     } else {
-      setMonster({
-        ...monster,
-        abilities: [...monster.abilities, new MonsterAbility(updatedAbility)],
-      });
+      // setMonster({
+      //   ...monster,
+      //   abilities: [...monster.abilities, new MonsterAbility(updatedAbility)],
+      // });
     }
   };
 
@@ -135,12 +153,12 @@ function Monster() {
    * @param id the id of the ability to remove
    */
   const removeAbility = (id: string) => {
-    setMonster({
-      ...monster,
-      abilities: [
-        ...monster.abilities.filter((ability: MonsterAbility) => ability.id !== id),
-      ],
-    });
+    // setMonster({
+    //   ...monster,
+    //   abilities: [
+    //     ...monster.abilities.filter((ability: MonsterAbility) => ability.id !== id),
+    //   ],
+    // });
   };
 
   /**
@@ -149,46 +167,46 @@ function Monster() {
    * @param updatedActopm The action item to update or add
    */
   const updateMonsterActions = (updatedAction: MonsterAction) => {
-    let actionsProperty: string = '';
+    // let actionsProperty: string = '';
 
-    switch (updatedAction.actionType) {
-      case 'Action':
-        actionsProperty = 'actions';
-        break;
-      case 'Reaction':
-        actionsProperty = 'reactions';
-        break;
-      case 'Legendary':
-        actionsProperty = 'legenActions';
-        break;
-      case 'lair':
-        actionsProperty = 'lairActions';
-        break;
-    }
+    // switch (updatedAction.actionType) {
+    //   case 'Action':
+    //     actionsProperty = 'actions';
+    //     break;
+    //   case 'Reaction':
+    //     actionsProperty = 'reactions';
+    //     break;
+    //   case 'Legendary':
+    //     actionsProperty = 'legenActions';
+    //     break;
+    //   case 'lair':
+    //     actionsProperty = 'lairActions';
+    //     break;
+    // }
 
-    // Check to see if we have an already existing ability item
-    const existingIndex: number = monster[`${actionsProperty}`].findIndex(
-      (action: MonsterAction) => action.id === updatedAction.id
-    );
+    // // Check to see if we have an already existing ability item
+    // const existingIndex: number = monster[`${actionsProperty}`].findIndex(
+    //   (action: MonsterAction) => action.id === updatedAction.id
+    // );
 
-    if (existingIndex > -1) {
-      // Copy the array so we don't have a chance to manipulate it before wanted
-      const actions = [...monster[`${actionsProperty}`]];
-      actions[existingIndex] = new MonsterAction(updatedAction);
+    // if (existingIndex > -1) {
+    //   // Copy the array so we don't have a chance to manipulate it before wanted
+    //   const actions = [...monster[`${actionsProperty}`]];
+    //   actions[existingIndex] = new MonsterAction(updatedAction);
 
-      setMonster({
-        ...monster,
-        actions,
-      });
-    } else {
-      setMonster({
-        ...monster,
-        [actionsProperty]: [
-          ...monster[`${actionsProperty}`],
-          new MonsterAction(updatedAction),
-        ],
-      });
-    }
+    //   setMonster({
+    //     ...monster,
+    //     actions,
+    //   });
+    // } else {
+    //   setMonster({
+    //     ...monster,
+    //     [actionsProperty]: [
+    //       ...monster[`${actionsProperty}`],
+    //       new MonsterAction(updatedAction),
+    //     ],
+    //   });
+    // }
   };
 
   /**
@@ -196,12 +214,12 @@ function Monster() {
    * @param id the id of the ability to remove
    */
   const removeAction = (id: string, actionType: string) => {
-    setMonster({
-      ...monster,
-      actions: [
-        ...monster.actions.filter((action: MonsterAction) => action.id !== id),
-      ],
-    });
+    // setMonster({
+    //   ...monster,
+    //   actions: [
+    //     ...monster.actions.filter((action: MonsterAction) => action.id !== id),
+    //   ],
+    // });
   };
 
   /**
@@ -209,19 +227,19 @@ function Monster() {
    * and sets it to the monster type
    */
   const importConfig = ({ target }: any) => {
-    const fileReader: FileReader = new FileReader();
+    // const fileReader: FileReader = new FileReader();
 
-    fileReader.onload = (e) => {
-      try {
-        const importedObject: object = JSON.parse(e.target.result as string);
-        setMonster(new MonsterDefinition(importedObject));
-        alert('Monster Has Been Uploaded');
-      } catch (e) {
-        alert('Error parsing file');
-        console.error(e);
-      }
-    };
-    fileReader.readAsText(target.files[0]);
+    // fileReader.onload = (e) => {
+    //   try {
+    //     const importedObject: object = JSON.parse(e.target.result as string);
+    //     setMonster(new MonsterDefinition(importedObject));
+    //     alert('Monster Has Been Uploaded');
+    //   } catch (e) {
+    //     alert('Error parsing file');
+    //     console.error(e);
+    //   }
+    // };
+    // fileReader.readAsText(target.files[0]);
   };
 
   /**
@@ -285,132 +303,6 @@ function Monster() {
     });
   };
 
-  /**
-   * Generates an example monster based off the 5e lich which can be located
-   * https://roll20.net/compendium/dnd5e/Lich
-   */
-  const generateExample = () => {
-    setMonster(
-      new MonsterDefinition({
-        name: 'Lich',
-        size: 'Medium',
-        type: 'Undead',
-        alignment: 'Neutral Evil',
-        armourClass: '17',
-        hitPoints: '135',
-        hitDie: '18d8+54',
-        landSpeed: '30',
-        str: '11',
-        dex: '16',
-        con: '16',
-        int: '20',
-        wis: '14',
-        chr: '16',
-        profBonus: '7',
-        challengeRating: '21',
-        rewardXP: '33000',
-        savingThrows: ['con', 'int', 'wis'],
-        proficiencies: ['arc', 'hst', 'ins', 'per'],
-        resistances: ['Cold', 'Lightning', 'Necrotic'],
-        immunities: ['Poison', 'Bludgeoning', 'Piercing', 'Slashing'],
-        condImmunities: [
-          'Charmed',
-          'Exhaustion',
-          'Frightenened',
-          'Paralyzed',
-          'Poisoned',
-        ],
-        truesight: '120',
-        languages: ['Common', 'Elvish', 'Celestial', 'Sylvan', 'Primordial'],
-        abilities: [
-          new MonsterAbility({
-            name: 'Legendary Resistance (3/Day)',
-            description:
-              'If the lich fails a saving throw, it can choose to succeed instead.',
-          }),
-          new MonsterAbility({
-            name: 'Rejuvenation',
-            description:
-              'If it has a phylactery, a destroyed lich gains a new body in 1d10 ' +
-              'days, regaining all its hit points and becoming active again. The ' +
-              'new body appears within 5 feet of the phylactery.',
-          }),
-          new MonsterAbility({
-            name: 'Spellcasting',
-            description:
-              'The lich is an 18th-level spellcaster. Its spellcasting ability is ' +
-              'Intelligence (spell save DC 20, +12 to hit with spell attacks). ' +
-              'The lich has the following wizard spells prepared: \n' +
-              'Cantrips (at will): mage hand, prestidigitation, ray of frost \n' +
-              ' 1st level (4 slots): detect magic, magic missile, shield, thunderwave \n' +
-              ' 2nd level (3 slots): detect thoughts, invisibility, acid arrow, mirror image \n' +
-              ' 3rd level (3 slots): animate dead, counterspell, dispel magic, fireball \n' +
-              ' 4th level (3 slots): blight, dimension door \n' +
-              ' 5th level (3 slots): cloudkill, scrying \n' +
-              ' 6th level (1 slot): disintegrate, globe of invulnerability \n' +
-              ' 7th level (1 slot): finger of death, plane shift \n' +
-              ' 8th level (1 slot): dominate monster, power word stun \n' +
-              ' 9th level (1 slot): power word kill',
-          }),
-          new MonsterAbility({
-            name: 'Turn Resistance',
-            description:
-              'The lich has advantage on saving throws against any effect that turns undead.',
-          }),
-        ],
-        actions: [
-          new MonsterAction({
-            name: 'Paralyzing Touch',
-            isAttack: true,
-            attackType: 'Melee Spell Attack',
-            toHit: '12',
-            reach: '5',
-            damage: '3d6',
-            damageType: 'Cold',
-            description:
-              'The target must succeed on a DC 18 Constitution saving ' +
-              'throw or be paralyzed for 1 minute. The target can repeat the ' +
-              'saving throw at the end of each of its turns, ending the effect on ' +
-              'itself on a success',
-          }),
-        ],
-        legenActions: [
-          new MonsterAction({
-            name: 'Cantrip',
-            isAttack: false,
-            description: 'The lich castrs a cantrip',
-          }),
-          new MonsterAction({
-            name: 'Paralyzing Touch (Costs 2 Actions)',
-            isAttack: false,
-            description: 'The lich uses its Paralyzing Touch.',
-          }),
-          new MonsterAction({
-            name: 'Frightening Gaze (Costs 2 Actions)',
-            isAttack: false,
-            description:
-              'The lich fixes its gaze on one creature it can see ' +
-              'within 10 feet of it. The target must succeed on a DC 18 Wisdom ' +
-              'saving throw against this magic or become frightened for 1 minute. ' +
-              'The frightened target can repeat the saving throw at the end of ' +
-              'each of its turns, ending the effect on itself on a success. ' +
-              "If a target's saving throw is successful or the effect ends for " +
-              "it, the target is immune to the lich's gaze for the next 24 hours.",
-          }),
-          new MonsterAction({
-            name: 'Disrupt Life (Costs 3 Actions)',
-            isAttack: false,
-            description:
-              'Each non-undead creature within 20 feet of the lich ' +
-              'must make a DC 18 Constitution saving throw against this magic, ' +
-              'taking 21 (6d6) necrotic damage on a failed save, or half as much ' +
-              'damage on a successful one.',
-          }),
-        ],
-      })
-    );
-  };
-
   return (
     <Box className={classes.root}>
       <Box className={classes.monsterContainer}>
@@ -423,10 +315,10 @@ function Monster() {
           </ExpansionPanelSummary>
           <ExpansionPanelDetails>
             <MonsterDescription
-              name={monster.name}
-              size={monster.size}
-              type={monster.type}
-              alignment={monster.alignment}
+              name={custMonster.name}
+              size={custMonster.size}
+              type={custMonster.type}
+              alignment={custMonster.alignment}
               handleChange={handleChange}
             />
           </ExpansionPanelDetails>
@@ -441,11 +333,11 @@ function Monster() {
           </ExpansionPanelSummary>
           <ExpansionPanelDetails>
             <MonsterSpeed
-              landSpeed={monster.landSpeed}
-              flySpeed={monster.flySpeed}
-              burrowSpeed={monster.burrowSpeed}
-              climbSpeed={monster.climbSpeed}
-              hoverSpeed={monster.hoverSpeed}
+              landSpeed={custMonster.landSpeed}
+              flySpeed={custMonster.flySpeed}
+              burrowSpeed={custMonster.burrowSpeed}
+              climbSpeed={custMonster.climbSpeed}
+              hoverSpeed={custMonster.hoverSpeed}
               handleChange={handleChange}
             />
           </ExpansionPanelDetails>
@@ -461,18 +353,18 @@ function Monster() {
           <ExpansionPanelDetails>
             <MonsterStats
               handleChange={handleChange}
-              armourClass={monster.armourClass}
-              hitPoints={monster.hitPoints}
-              hitDie={monster.hitDie}
-              str={monster.str}
-              dex={monster.dex}
-              con={monster.con}
-              int={monster.int}
-              wis={monster.wis}
-              chr={monster.chr}
-              profBonus={monster.profBonus}
-              proficiencies={monster.proficiencies}
-              savingThrows={monster.savingThrows}
+              armourClass={custMonster.armourClass}
+              hitPoints={custMonster.hitPoints}
+              hitDie={custMonster.hitDie}
+              str={custMonster.str}
+              dex={custMonster.dex}
+              con={custMonster.con}
+              int={custMonster.int}
+              wis={custMonster.wis}
+              chr={custMonster.chr}
+              profBonus={custMonster.profBonus}
+              proficiencies={custMonster.proficiencies}
+              savingThrows={custMonster.savingThrows}
             />
           </ExpansionPanelDetails>
         </ExpansionPanel>
@@ -486,10 +378,10 @@ function Monster() {
           </ExpansionPanelSummary>
           <ExpansionPanelDetails>
             <MonsterSenses
-              blindsight={monster.blindsight}
-              darkvision={monster.darkvision}
-              tremorsense={monster.tremorsense}
-              truesight={monster.truesight}
+              blindsight={custMonster.blindsight}
+              darkvision={custMonster.darkvision}
+              tremorsense={custMonster.tremorsense}
+              truesight={custMonster.truesight}
               handleChange={handleChange}
             />
           </ExpansionPanelDetails>
@@ -504,13 +396,13 @@ function Monster() {
           </ExpansionPanelSummary>
           <ExpansionPanelDetails>
             <MonsterProperties
-              immunities={monster.immunities}
-              condImmunities={monster.condImmunities}
-              resistances={monster.resistances}
-              weaknesses={monster.weaknesses}
-              languages={monster.languages}
-              challengeRating={monster.challengeRating}
-              rewardXP={monster.rewardXP}
+              immunities={custMonster.immunities}
+              condImmunities={custMonster.condImmunities}
+              resistances={custMonster.resistances}
+              weaknesses={custMonster.weaknesses}
+              languages={custMonster.languages}
+              challengeRating={custMonster.challengeRating}
+              rewardXP={custMonster.rewardXP}
               handleChange={handleChange}
             />
           </ExpansionPanelDetails>
@@ -525,8 +417,6 @@ function Monster() {
           </ExpansionPanelSummary>
           <ExpansionPanelDetails>
             <MonsterAbilities
-              monsterAbilities={monster.abilities}
-              addMonsterAbility={updateMonsterAbilities}
               removeAbility={removeAbility}
             />
           </ExpansionPanelDetails>
@@ -541,10 +431,10 @@ function Monster() {
           </ExpansionPanelSummary>
           <ExpansionPanelDetails>
             <MonsterActions
-              actions={monster.actions}
-              legenActions={monster.legenActions}
-              lairActions={monster.lairActions}
-              reactions={monster.reactions}
+              actions={custMonster.actions}
+              legenActions={custMonster.legenActions}
+              lairActions={custMonster.lairActions}
+              reactions={custMonster.reactions}
               addMonsterAction={updateMonsterActions}
               removeAction={removeAction}
             />
@@ -557,7 +447,7 @@ function Monster() {
               color="primary"
               variant="contained"
               aria-label="Load Example"
-              onClick={generateExample}
+              onClick={loadExample}
             >
               Example
             </Button>
@@ -609,10 +499,10 @@ function Monster() {
         </Box>
       </Box>
       <div className={classes.statBlockContainer}>
-        <StatBlock monster={monster} twoColumns={twoCols} saveRef={componentRef} />
+        <StatBlock twoColumns={twoCols} saveRef={componentRef} />
       </div>
     </Box>
   );
-}
+});
 
 export default Monster;

--- a/src/components/monster/Monster.tsx
+++ b/src/components/monster/Monster.tsx
@@ -337,7 +337,6 @@ const Monster = connect(mapState, mapDispatch)(({custMonster, loadExample}: Prop
               burrowSpeed={custMonster.burrowSpeed}
               climbSpeed={custMonster.climbSpeed}
               hoverSpeed={custMonster.hoverSpeed}
-              handleChange={handleChange}
             />
           </ExpansionPanelDetails>
         </ExpansionPanel>
@@ -351,7 +350,6 @@ const Monster = connect(mapState, mapDispatch)(({custMonster, loadExample}: Prop
           </ExpansionPanelSummary>
           <ExpansionPanelDetails>
             <MonsterStats
-              handleChange={handleChange}
               armourClass={custMonster.armourClass}
               hitPoints={custMonster.hitPoints}
               hitDie={custMonster.hitDie}

--- a/src/components/monster/Monster.tsx
+++ b/src/components/monster/Monster.tsx
@@ -23,18 +23,19 @@ import {
   Box,
   FormControlLabel,
   Switch,
+  makeStyles,
+  createStyles,
 } from '@material-ui/core';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import MonsterAbility from '../../models/MonsterAbility';
 import MonsterAction from '../../models/MonsterAction';
 import MonsterDefinition from '../../models/MonsterDefinition';
 import StatBlock from './stat-block/StatBlock';
-import PropTypes, { InferProps } from 'prop-types';
 import ReactDOM from 'react-dom';
 import html2canvas from 'html2canvas';
 
 /** Setup the styles and theming for this component and children */
-const styles = (theme: Theme) => ({
+const useStyles = makeStyles((theme: Theme) => createStyles({
   root: {
     width: '100%',
     display: 'inline-block',
@@ -81,13 +82,15 @@ const styles = (theme: Theme) => ({
       width: '100%',
     },
   },
-});
+}));
 
-function Monster({ classes }: InferProps<typeof Monster.propTypes>) {
+function Monster() {
   const [monster, setMonster] = useState(new MonsterDefinition());
   const [twoCols, setTwoCols] = useState(false);
 
   const componentRef = useRef();
+  
+  const classes = useStyles();
 
   /**
    * Updates the state of the monster on a change.
@@ -615,8 +618,4 @@ function Monster({ classes }: InferProps<typeof Monster.propTypes>) {
   );
 }
 
-Monster.propTypes = {
-  classes: PropTypes.any,
-};
-
-export default withStyles(styles, { withTheme: true })(Monster);
+export default Monster;

--- a/src/components/monster/monster-abilities/AddMonsterAbility.tsx
+++ b/src/components/monster/monster-abilities/AddMonsterAbility.tsx
@@ -49,11 +49,13 @@ const useStyles = makeStyles((theme: Theme) => createStyles({
 
 type Props = {
   addMonsterAbility: (ability: MonsterAbility) => unknown;
+  updateMonsterAbility: (ability: MonsterAbility) => unknown;
   editAbility: MonsterAbility;
 }
 
 function AddMonsterAbility({
   addMonsterAbility,
+  updateMonsterAbility,
   editAbility,
 }: Props) {
   const [ability, setAbility] = useState({ name: '', description: ''} as MonsterAbility);
@@ -92,21 +94,26 @@ function AddMonsterAbility({
     } as MonsterAbility);
   };
 
+  /** Sets the state to the default new ability state */
+  const newAbilityState = () => {
+    setAbility({name: '', description: ''} as MonsterAbility);
+    setIsNew(true);
+  }
+
   /**
    * Add or edit a monster ability by passing it up to the parent
    * and then reset the state
    */
   const addAbility = () => {
     addMonsterAbility(ability);
-    setAbility({name: '', description: ''} as MonsterAbility);
-    setIsNew(true);
+    newAbilityState();
   };
 
-  /** Cancels editting a monster ability */
-  const cancelEdit = () => {
-    setAbility({name: '', description: ''} as MonsterAbility);
-    setIsNew(true);
-  };
+  /** Updates the monster ability that has been passed in */
+  const updateAbility = () => {
+    updateMonsterAbility(ability);
+    newAbilityState();
+  }
 
   return (
     <>
@@ -142,7 +149,7 @@ function AddMonsterAbility({
             color="primary"
             variant="contained"
             aria-label="Save Ability"
-            onClick={addAbility}
+            onClick={isNew ? addAbility : updateAbility}
           >
             {isNew ? 'Save' : 'Update'}
           </Button>
@@ -152,7 +159,7 @@ function AddMonsterAbility({
               variant="contained"
               aria-label="Cancel Edit"
               style={{ marginLeft: '8px' }}
-              onClick={cancelEdit}
+              onClick={newAbilityState}
             >
               Cancel
             </Button>

--- a/src/components/monster/monster-abilities/AddMonsterAbility.tsx
+++ b/src/components/monster/monster-abilities/AddMonsterAbility.tsx
@@ -3,11 +3,10 @@
  * Handles adding an individual monster property with the title and description
  */
 import React, { useState, useEffect } from 'react';
-import { TextField, Button, Box, Theme, withStyles } from '@material-ui/core';
-import PropTypes, { InferProps } from 'prop-types';
+import { TextField, Button, Box, makeStyles, createStyles, Theme } from '@material-ui/core';
 import MonsterAbility from '../../../models/MonsterAbility';
 
-const useStyles = (theme: Theme) => ({
+const useStyles = makeStyles((theme: Theme) => createStyles({
   root: {
     display: 'flex',
     'flex-direction': 'row',
@@ -46,15 +45,21 @@ const useStyles = (theme: Theme) => ({
       display: 'inline-block',
     },
   },
-});
+}));
+
+type Props = {
+  addMonsterAbility: (ability: MonsterAbility) => unknown;
+  editAbility: MonsterAbility;
+}
 
 function AddMonsterAbility({
   addMonsterAbility,
   editAbility,
-  classes,
-}: InferProps<typeof AddMonsterAbility.propTypes>) {
+}: Props) {
   const [ability, setAbility] = useState(new MonsterAbility({}));
   const [isNew, setIsNew] = useState(true);
+
+  const classes = useStyles();
 
   /**
    * An effect that checks if the editAbility prop has been change
@@ -158,10 +163,4 @@ function AddMonsterAbility({
   );
 }
 
-AddMonsterAbility.propTypes = {
-  addMonsterAbility: PropTypes.func.isRequired,
-  editAbility: PropTypes.instanceOf(MonsterAbility),
-  classes: PropTypes.any,
-};
-
-export default withStyles(useStyles, { withTheme: true })(AddMonsterAbility);
+export default AddMonsterAbility;

--- a/src/components/monster/monster-abilities/AddMonsterAbility.tsx
+++ b/src/components/monster/monster-abilities/AddMonsterAbility.tsx
@@ -56,7 +56,7 @@ function AddMonsterAbility({
   addMonsterAbility,
   editAbility,
 }: Props) {
-  const [ability, setAbility] = useState(new MonsterAbility({}));
+  const [ability, setAbility] = useState({ name: '', description: ''} as MonsterAbility);
   const [isNew, setIsNew] = useState(true);
 
   const classes = useStyles();
@@ -70,14 +70,14 @@ function AddMonsterAbility({
   useEffect(() => {
     if (editAbility == null) {
       setIsNew(true);
-      setAbility(new MonsterAbility({}));
+      setAbility({name: '', description: ''} as MonsterAbility);
     } else {
       setIsNew(false);
       setAbility(editAbility);
     }
 
     return () => {
-      setAbility(new MonsterAbility({}));
+      setAbility({name: '', description: ''} as MonsterAbility);
     };
   }, [editAbility]);
 
@@ -98,13 +98,13 @@ function AddMonsterAbility({
    */
   const addAbility = () => {
     addMonsterAbility(ability);
-    setAbility(new MonsterAbility());
+    setAbility({name: '', description: ''} as MonsterAbility);
     setIsNew(true);
   };
 
   /** Cancels editting a monster ability */
   const cancelEdit = () => {
-    setAbility(new MonsterAbility());
+    setAbility({name: '', description: ''} as MonsterAbility);
     setIsNew(true);
   };
 

--- a/src/components/monster/monster-abilities/MonsterAbilities.tsx
+++ b/src/components/monster/monster-abilities/MonsterAbilities.tsx
@@ -27,6 +27,7 @@ const mapState = (state: AppState) => ({
 const mapDispatch = (dispatch: Dispatch) => ({
   addAbility: (ability: MonsterAbility) => dispatch(monster.actions.addAbility(ability)),
   updateAbility: (ability: MonsterAbility) => dispatch(monster.actions.updateAbility(ability)),
+  removeAbility: (id: string) => dispatch(monster.actions.removeAbility(id)),
 });
 
 const MonsterAbilities = connect(mapState, mapDispatch)(({

--- a/src/components/monster/monster-abilities/MonsterAbilities.tsx
+++ b/src/components/monster/monster-abilities/MonsterAbilities.tsx
@@ -4,20 +4,37 @@
  */
 import React, { useState } from 'react';
 import AddMonsterAbility from './AddMonsterAbility';
+import { Dispatch } from 'redux';
+import { connect } from 'react-redux';
 import MonsterAbilitiesList from './MonsterAbilitiesList';
 import MonsterAbility from '../../../models/MonsterAbility';
+import { abilitiesSelector } from '../../../selectors/monsterSelector';
+import { AppState } from '../../../store/store';
+import monster from '../../../reducers/monsterReducer';
 
 type Props = {
-  monsterAbilities: Array<MonsterAbility>;
-  addMonsterAbility: () => unknown;
-  removeAbility: () => unknown;
+  abilities: Array<MonsterAbility>;
+  addAbility: (updatedAbility: MonsterAbility) => unknown;
+  removeAbility: (id: string) => unknown;
 }
 
-function MonsterAbilities({
-  monsterAbilities,
-  addMonsterAbility,
+/** Setup the abilities state */
+const mapState = (state: AppState) => ({
+  abilities: abilitiesSelector(state),
+});
+
+const mapDispatch = (dispatch: Dispatch) => ({
+  // addMonsterAbility: (ability: MonsterAbility) => dispatch(monster.actions.addAbility(ability)),
+  addAbility: (ability: MonsterAbility) => dispatch(monster.actions.addAbility(ability)),
+
+  // displayItem: (item: Item) => dispatch(items.actions.displayItem(item))
+});
+
+const MonsterAbilities = connect(mapState, mapDispatch)(({
+  abilities,
+  addAbility,
   removeAbility,
-}: Props) {
+}: Props) => {
   const [edittingAbility, setEdittingAbility] = useState(null);
 
   /**
@@ -33,16 +50,16 @@ function MonsterAbilities({
   return (
     <div style={{ width: '100%' }}>
       <AddMonsterAbility
-        addMonsterAbility={addMonsterAbility}
+        addMonsterAbility={addAbility}
         editAbility={edittingAbility}
       />
       <MonsterAbilitiesList
-        monsterAbilities={monsterAbilities}
+        monsterAbilities={abilities}
         removeAbility={removeAbility}
         editAbility={editAbility}
       />
     </div>
   );
-}
+})
 
 export default MonsterAbilities;

--- a/src/components/monster/monster-abilities/MonsterAbilities.tsx
+++ b/src/components/monster/monster-abilities/MonsterAbilities.tsx
@@ -6,13 +6,18 @@ import React, { useState } from 'react';
 import AddMonsterAbility from './AddMonsterAbility';
 import MonsterAbilitiesList from './MonsterAbilitiesList';
 import MonsterAbility from '../../../models/MonsterAbility';
-import PropTypes, { InferProps } from 'prop-types';
+
+type Props = {
+  monsterAbilities: Array<MonsterAbility>;
+  addMonsterAbility: () => unknown;
+  removeAbility: () => unknown;
+}
 
 function MonsterAbilities({
   monsterAbilities,
   addMonsterAbility,
   removeAbility,
-}: InferProps<typeof MonsterAbilities.propTypes>) {
+}: Props) {
   const [edittingAbility, setEdittingAbility] = useState(null);
 
   /**
@@ -39,12 +44,5 @@ function MonsterAbilities({
     </div>
   );
 }
-
-MonsterAbilities.propTypes = {
-  monsterAbilities: PropTypes.arrayOf(PropTypes.instanceOf(MonsterAbility))
-    .isRequired,
-  addMonsterAbility: PropTypes.func.isRequired,
-  removeAbility: PropTypes.func.isRequired,
-};
 
 export default MonsterAbilities;

--- a/src/components/monster/monster-abilities/MonsterAbilities.tsx
+++ b/src/components/monster/monster-abilities/MonsterAbilities.tsx
@@ -14,7 +14,8 @@ import monster from '../../../reducers/monsterReducer';
 
 type Props = {
   abilities: Array<MonsterAbility>;
-  addAbility: (updatedAbility: MonsterAbility) => unknown;
+  addAbility: (ability: MonsterAbility) => unknown;
+  updateAbility: (ability: MonsterAbility) => unknown;
   removeAbility: (id: string) => unknown;
 }
 
@@ -24,15 +25,14 @@ const mapState = (state: AppState) => ({
 });
 
 const mapDispatch = (dispatch: Dispatch) => ({
-  // addMonsterAbility: (ability: MonsterAbility) => dispatch(monster.actions.addAbility(ability)),
   addAbility: (ability: MonsterAbility) => dispatch(monster.actions.addAbility(ability)),
-
-  // displayItem: (item: Item) => dispatch(items.actions.displayItem(item))
+  updateAbility: (ability: MonsterAbility) => dispatch(monster.actions.updateAbility(ability)),
 });
 
 const MonsterAbilities = connect(mapState, mapDispatch)(({
   abilities,
   addAbility,
+  updateAbility,
   removeAbility,
 }: Props) => {
   const [edittingAbility, setEdittingAbility] = useState(null);
@@ -51,6 +51,7 @@ const MonsterAbilities = connect(mapState, mapDispatch)(({
     <div style={{ width: '100%' }}>
       <AddMonsterAbility
         addMonsterAbility={addAbility}
+        updateMonsterAbility={updateAbility}
         editAbility={edittingAbility}
       />
       <MonsterAbilitiesList

--- a/src/components/monster/monster-abilities/MonsterAbilitiesList.tsx
+++ b/src/components/monster/monster-abilities/MonsterAbilitiesList.tsx
@@ -3,23 +3,29 @@
  * Displays a list of abilities that a monster may have.
  */
 import React from 'react';
-import PropTypes, { InferProps } from 'prop-types';
 import MonsterAbility from '../../../models/MonsterAbility';
 import MonsterAbilityListItem from './MonsterAbilityListItem';
-import { List, withStyles } from '@material-ui/core';
+import { createStyles, List, makeStyles, withStyles } from '@material-ui/core';
 
-const useStyles = () => ({
+const useStyles = makeStyles(() => createStyles({
   list: {
     width: '100%',
   },
-});
+}));
+
+type Props = {
+  monsterAbilities: Array<MonsterAbility>;
+  removeAbility: () => unknown;
+  editAbility: (ability: MonsterAbility) => unknown;
+}
 
 function MonsterAbilitiesList({
   monsterAbilities,
   removeAbility,
   editAbility,
-  classes,
-}: InferProps<typeof MonsterAbilitiesList.propTypes>) {
+}: Props) {
+  const classes = useStyles();
+
   return (
     <>
       <List className={classes.list}>
@@ -36,11 +42,4 @@ function MonsterAbilitiesList({
   );
 }
 
-MonsterAbilitiesList.propTypes = {
-  monsterAbilities: PropTypes.array.isRequired,
-  removeAbility: PropTypes.func.isRequired,
-  editAbility: PropTypes.func.isRequired,
-  classes: PropTypes.any,
-};
-
-export default withStyles(useStyles, { withTheme: true })(MonsterAbilitiesList);
+export default MonsterAbilitiesList;

--- a/src/components/monster/monster-abilities/MonsterAbilitiesList.tsx
+++ b/src/components/monster/monster-abilities/MonsterAbilitiesList.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import MonsterAbility from '../../../models/MonsterAbility';
 import MonsterAbilityListItem from './MonsterAbilityListItem';
-import { createStyles, List, makeStyles, withStyles } from '@material-ui/core';
+import { createStyles, List, makeStyles } from '@material-ui/core';
 
 const useStyles = makeStyles(() => createStyles({
   list: {
@@ -15,15 +15,15 @@ const useStyles = makeStyles(() => createStyles({
 
 type Props = {
   monsterAbilities: Array<MonsterAbility>;
-  removeAbility: () => unknown;
+  removeAbility: (id: string) => unknown;
   editAbility: (ability: MonsterAbility) => unknown;
 }
 
-function MonsterAbilitiesList({
+const MonsterAbilitiesList = (({
   monsterAbilities,
   removeAbility,
   editAbility,
-}: Props) {
+}: Props) => {
   const classes = useStyles();
 
   return (
@@ -40,6 +40,6 @@ function MonsterAbilitiesList({
       </List>
     </>
   );
-}
+});
 
 export default MonsterAbilitiesList;

--- a/src/components/monster/monster-abilities/MonsterAbilityListItem.tsx
+++ b/src/components/monster/monster-abilities/MonsterAbilityListItem.tsx
@@ -32,7 +32,7 @@ export default function MonsterAbilityListItem({
         <ListItemSecondaryAction>
           <IconButton
             aria-label="edit ability"
-            onClick={editAbility.bind(this, ability)}
+            onClick={() => editAbility(ability)}
           >
             <EditIcon />
           </IconButton>

--- a/src/components/monster/monster-abilities/MonsterAbilityListItem.tsx
+++ b/src/components/monster/monster-abilities/MonsterAbilityListItem.tsx
@@ -38,7 +38,7 @@ export default function MonsterAbilityListItem({
           </IconButton>
           <IconButton
             aria-label="delete ability"
-            onClick={removeAbility.bind(this, ability.id)}
+            onClick={() => removeAbility(ability.id)}
           >
             <DeleteIcon style={{ color: '#ff0000' }} />
           </IconButton>

--- a/src/components/monster/monster-abilities/MonsterAbilityListItem.tsx
+++ b/src/components/monster/monster-abilities/MonsterAbilityListItem.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes, { InferProps } from 'prop-types';
 import {
   ListItem,
   ListItemText,
@@ -11,11 +10,17 @@ import MonsterAbility from '../../../models/MonsterAbility';
 import DeleteIcon from '@material-ui/icons/Delete';
 import EditIcon from '@material-ui/icons/Edit';
 
+type Props = {
+  ability: MonsterAbility;
+  removeAbility: (id: string) => unknown;
+  editAbility: (ability: MonsterAbility) => unknown;
+}
+
 export default function MonsterAbilityListItem({
   ability,
   removeAbility,
   editAbility,
-}: InferProps<typeof MonsterAbilityListItem.propTypes>) {
+}: Props) {
   return (
     <>
       <ListItem>
@@ -43,9 +48,3 @@ export default function MonsterAbilityListItem({
     </>
   );
 }
-
-MonsterAbilityListItem.propTypes = {
-  ability: PropTypes.instanceOf(MonsterAbility).isRequired,
-  removeAbility: PropTypes.func.isRequired,
-  editAbility: PropTypes.func.isRequired,
-};

--- a/src/components/monster/monster-actions/AddMonsterAction.tsx
+++ b/src/components/monster/monster-actions/AddMonsterAction.tsx
@@ -98,10 +98,12 @@ const useStyles = makeStyles((theme: Theme) => createStyles({
 
 type Props = {
   addMonsterAction: (action: MonsterAction) => unknown;
+  updateMonsterAction: (action: MonsterAction) => unknown;
   editAction: MonsterAction;
 }
 function AddMonsterAction({
   addMonsterAction,
+  updateMonsterAction,
   editAction
 }: Props) {
   const [action, setAction] = useState({
@@ -202,13 +204,21 @@ function AddMonsterAction({
   };
 
   /**
-   * Add or edit a monster action by passing it up to the parent
+   * Add a monster action by passing it up to the parent
    * and then reset the state of the action inputs
    */
   const addAction = () => {
     addMonsterAction(action);
     newActionState();
   };
+
+  /**
+   * Update a monster action by passing it up the state
+   */
+  const updateAction = () => {
+    updateMonsterAction(action);
+    newActionState();
+  }
 
   /**
    * Cancels editting an action setting the state
@@ -353,7 +363,7 @@ function AddMonsterAction({
             color="primary"
             variant="contained"
             aria-label="Save Action"
-            onClick={addAction}
+            onClick={isNew ? addAction : updateAction}
           >
             {isNew ? 'Save' : 'Update'}
           </Button>

--- a/src/components/monster/monster-actions/AddMonsterAction.tsx
+++ b/src/components/monster/monster-actions/AddMonsterAction.tsx
@@ -105,7 +105,17 @@ function AddMonsterAction({
   addMonsterAction,
   editAction
 }: Props) {
-  const [action, setAction] = useState(new MonsterAction({}));
+  const [action, setAction] = useState({
+    name: '',
+    description: '',
+    actionType: '',
+    isAttack: false,
+    attackType: '',
+    toHit: '',
+    damage: '',
+    damageType: '',
+    reach: '',
+  } as MonsterAction);
   const [isNew, setIsNew] = useState(true);
 
   const classes = useStyles();
@@ -130,11 +140,11 @@ function AddMonsterAction({
     if (!action.isAttack) {
       setAction({
         ...action,
-        attackType: null,
-        toHit: null,
-        damage: null,
-        damageType: null,
-        reach: null,
+        attackType: '',
+        toHit: '',
+        damage: '',
+        damageType: '',
+        reach: '',
       });
     }
   }, [action.isAttack]);
@@ -147,17 +157,28 @@ function AddMonsterAction({
    */
   useEffect(() => {
     if (editAction == null) {
-      setIsNew(true);
-      setAction(new MonsterAction({}));
+      newActionState();
     } else {
       setIsNew(false);
       setAction(editAction);
     }
-
-    return () => {
-      setAction(new MonsterAction({}));
-    };
   }, [editAction]);
+
+  /** Reset the action to a new action */
+  const newActionState = () => {
+    setAction({
+      name: '',
+      description: '',
+      actionType: '',
+      isAttack: false,
+      attackType: '',
+      toHit: '',
+      damage: '',
+      damageType: '',
+      reach: '',
+    } as MonsterAction);
+    setIsNew(true);
+  }
 
   /**
    * Handles updating the
@@ -187,8 +208,7 @@ function AddMonsterAction({
    */
   const addAction = () => {
     addMonsterAction(action);
-    setAction(new MonsterAction());
-    setIsNew(true);
+    newActionState();
   };
 
   /**
@@ -196,8 +216,7 @@ function AddMonsterAction({
    * back to a new state
    */
   const cancelEdit = () => {
-    setAction(new MonsterAction());
-    setIsNew(true);
+    newActionState();
   };
 
   return (

--- a/src/components/monster/monster-actions/AddMonsterAction.tsx
+++ b/src/components/monster/monster-actions/AddMonsterAction.tsx
@@ -14,7 +14,6 @@ import {
   Checkbox,
   FormControlLabel,
   Theme,
-  withStyles,
   Button,
   makeStyles,
   createStyles,

--- a/src/components/monster/monster-actions/AddMonsterAction.tsx
+++ b/src/components/monster/monster-actions/AddMonsterAction.tsx
@@ -16,12 +16,13 @@ import {
   Theme,
   withStyles,
   Button,
+  makeStyles,
+  createStyles,
 } from '@material-ui/core';
-import PropTypes, { InferProps } from 'prop-types';
 import MonsterAction from '../../../models/MonsterAction';
 import { getDamageTypes } from '../../../hooks/getDamageTypes';
 
-const useStyles = (theme: Theme) => ({
+const useStyles = makeStyles((theme: Theme) => createStyles({
   inputField: { display: 'flex', margin: theme.spacing(1) },
   topRowContainer: {
     display: 'flex',
@@ -94,15 +95,20 @@ const useStyles = (theme: Theme) => ({
       width: '100%',
     },
   },
-});
+}));
 
+type Props = {
+  addMonsterAction: (action: MonsterAction) => unknown;
+  editAction: MonsterAction;
+}
 function AddMonsterAction({
   addMonsterAction,
-  editAction,
-  classes,
-}: InferProps<typeof AddMonsterAction.propTypes>) {
+  editAction
+}: Props) {
   const [action, setAction] = useState(new MonsterAction({}));
   const [isNew, setIsNew] = useState(true);
+
+  const classes = useStyles();
 
   /** List of action types available in 5e */
   const actionTypes: Array<string> = ['Action', 'Reaction', 'Legendary', 'Lair'];
@@ -350,10 +356,4 @@ function AddMonsterAction({
   );
 }
 
-AddMonsterAction.propTypes = {
-  addMonsterAction: PropTypes.func.isRequired,
-  editAction: PropTypes.instanceOf(MonsterAction),
-  classes: PropTypes.any,
-};
-
-export default withStyles(useStyles, { withTheme: true })(AddMonsterAction);
+export default AddMonsterAction;

--- a/src/components/monster/monster-actions/MonsterActionListItem.tsx
+++ b/src/components/monster/monster-actions/MonsterActionListItem.tsx
@@ -12,23 +12,21 @@ import MonsterAction from '../../../models/MonsterAction';
 
 type Props = {
   action: MonsterAction;
-  actionType: string;
   removeAction: () => unknown;
   editAction: () => unknown;
 }
 
 function MonsterActionListItem({
   action,
-  actionType,
   removeAction,
   editAction,
 }: Props) {
   const [actionSummary, setActionSummary] = useState('');
 
   useEffect(() => {
-    let summary: string = `${actionType} -`;
-    if (action.attackType != null) {
-      summary += ` ${action.attackType} Attack: ${action.toHit} to hit, reach ${action.reach}`;
+    let summary: string = `${action.actionType} -`;
+    if (action.isAttack && action.attackType !== '') {
+      summary += ` ${action.attackType}: ${action.toHit} to hit, reach ${action.reach}`;
       summary += `, Hit: ${action.damage} ${action.damageType} damage`;
     }
 

--- a/src/components/monster/monster-actions/MonsterActionListItem.tsx
+++ b/src/components/monster/monster-actions/MonsterActionListItem.tsx
@@ -12,8 +12,8 @@ import MonsterAction from '../../../models/MonsterAction';
 
 type Props = {
   action: MonsterAction;
-  removeAction: () => unknown;
-  editAction: () => unknown;
+  removeAction: (id: string) => unknown;
+  editAction: (action: MonsterAction) => unknown;
 }
 
 function MonsterActionListItem({
@@ -46,13 +46,13 @@ function MonsterActionListItem({
         <ListItemSecondaryAction>
           <IconButton
             aria-label="edit ability"
-            onClick={editAction.bind(this, action)}
+            onClick={() => editAction(action)}
           >
             <EditIcon />
           </IconButton>
           <IconButton
             aria-label="delete ability"
-            onClick={removeAction.bind(this, action.id)}
+            onClick={() => removeAction(action.id)}
           >
             <DeleteIcon style={{ color: '#ff0000' }} />
           </IconButton>

--- a/src/components/monster/monster-actions/MonsterActionListItem.tsx
+++ b/src/components/monster/monster-actions/MonsterActionListItem.tsx
@@ -9,14 +9,20 @@ import {
 import DeleteIcon from '@material-ui/icons/Delete';
 import EditIcon from '@material-ui/icons/Edit';
 import MonsterAction from '../../../models/MonsterAction';
-import PropTypes, { InferProps } from 'prop-types';
+
+type Props = {
+  action: MonsterAction;
+  actionType: string;
+  removeAction: () => unknown;
+  editAction: () => unknown;
+}
 
 function MonsterActionListItem({
   action,
   actionType,
   removeAction,
   editAction,
-}: InferProps<typeof MonsterActionListItem.propTypes>) {
+}: Props) {
   const [actionSummary, setActionSummary] = useState('');
 
   useEffect(() => {
@@ -58,12 +64,5 @@ function MonsterActionListItem({
     </>
   );
 }
-
-MonsterActionListItem.propTypes = {
-  action: PropTypes.instanceOf(MonsterAction).isRequired,
-  actionType: PropTypes.string.isRequired,
-  removeAction: PropTypes.func.isRequired,
-  editAction: PropTypes.func.isRequired,
-};
 
 export default MonsterActionListItem;

--- a/src/components/monster/monster-actions/MonsterActions.tsx
+++ b/src/components/monster/monster-actions/MonsterActions.tsx
@@ -12,8 +12,8 @@ type Props = {
   legenActions: Array<MonsterAction>;
   reactions: Array<MonsterAction>;
   lairActions: Array<MonsterAction>;
-  addMonsterAction: () => unknown;
-  removeAction: () => unknown;
+  addMonsterAction: (updatedAbility: MonsterAction) => unknown;
+  removeAction: (id: string, actionType: string) => unknown;
 }
 function MonsterActions({
   actions,

--- a/src/components/monster/monster-actions/MonsterActions.tsx
+++ b/src/components/monster/monster-actions/MonsterActions.tsx
@@ -6,9 +6,7 @@ import React, { useState } from 'react';
 import AddMonsterAction from './AddMonsterAction';
 import MonsterActionsList from './MonsterActionsList';
 import MonsterAction from '../../../models/MonsterAction';
-import { AppState } from '../../../store/store';
 import { Dispatch } from 'redux';
-import { actionsSelector } from '../../../selectors/monsterSelector';
 import monster from '../../../reducers/monsterReducer';
 import { connect } from 'react-redux';
 
@@ -20,8 +18,8 @@ type Props = {
 
 const mapDispatch = (dispatch: Dispatch) => ({
   addAction: (action: MonsterAction) => dispatch(monster.actions.addAction(action)),
-  updateAction: () => {},
-  removeAction: (id: string) => {},
+  updateAction: (action: MonsterAction) => dispatch(monster.actions.addAction(action)),
+  removeAction: (id: string) => dispatch(monster.actions.removeAction(id)),
 })
 
 const MonsterActions = connect(null, mapDispatch)(({

--- a/src/components/monster/monster-actions/MonsterActions.tsx
+++ b/src/components/monster/monster-actions/MonsterActions.tsx
@@ -6,8 +6,15 @@ import React, { useState } from 'react';
 import AddMonsterAction from './AddMonsterAction';
 import MonsterActionsList from './MonsterActionsList';
 import MonsterAction from '../../../models/MonsterAction';
-import PropTypes, { InferProps } from 'prop-types';
 
+type Props = {
+  actions: Array<MonsterAction>;
+  legenActions: Array<MonsterAction>;
+  reactions: Array<MonsterAction>;
+  lairActions: Array<MonsterAction>;
+  addMonsterAction: () => unknown;
+  removeAction: () => unknown;
+}
 function MonsterActions({
   actions,
   legenActions,
@@ -15,7 +22,7 @@ function MonsterActions({
   lairActions,
   addMonsterAction,
   removeAction,
-}: InferProps<typeof MonsterActions.propTypes>) {
+}: Props) {
   const [edittingAction, setEdittingAction] = useState(null);
 
   /**
@@ -46,14 +53,5 @@ function MonsterActions({
     </div>
   );
 }
-
-MonsterActions.propTypes = {
-  actions: PropTypes.arrayOf(PropTypes.instanceOf(MonsterAction)).isRequired,
-  reactions: PropTypes.arrayOf(PropTypes.instanceOf(MonsterAction)).isRequired,
-  legenActions: PropTypes.arrayOf(PropTypes.instanceOf(MonsterAction)).isRequired,
-  lairActions: PropTypes.arrayOf(PropTypes.instanceOf(MonsterAction)).isRequired,
-  addMonsterAction: PropTypes.func.isRequired,
-  removeAction: PropTypes.func.isRequired,
-};
 
 export default MonsterActions;

--- a/src/components/monster/monster-actions/MonsterActions.tsx
+++ b/src/components/monster/monster-actions/MonsterActions.tsx
@@ -6,23 +6,28 @@ import React, { useState } from 'react';
 import AddMonsterAction from './AddMonsterAction';
 import MonsterActionsList from './MonsterActionsList';
 import MonsterAction from '../../../models/MonsterAction';
+import { AppState } from '../../../store/store';
+import { Dispatch } from 'redux';
+import { actionsSelector } from '../../../selectors/monsterSelector';
+import monster from '../../../reducers/monsterReducer';
+import { connect } from 'react-redux';
+
 
 type Props = {
-  actions: Array<MonsterAction>;
-  legenActions: Array<MonsterAction>;
-  reactions: Array<MonsterAction>;
-  lairActions: Array<MonsterAction>;
-  addMonsterAction: (updatedAbility: MonsterAction) => unknown;
-  removeAction: (id: string, actionType: string) => unknown;
+  addAction: (updatedAbility: MonsterAction) => unknown;
+  removeAction: (id: string) => unknown;
 }
-function MonsterActions({
-  actions,
-  legenActions,
-  reactions,
-  lairActions,
-  addMonsterAction,
+
+const mapDispatch = (dispatch: Dispatch) => ({
+  addAction: (action: MonsterAction) => dispatch(monster.actions.addAction(action)),
+  updateAction: () => {},
+  removeAction: (id: string) => {},
+})
+
+const MonsterActions = connect(null, mapDispatch)(({
+  addAction,
   removeAction,
-}: Props) {
+}: Props) => {
   const [edittingAction, setEdittingAction] = useState(null);
 
   /**
@@ -39,19 +44,15 @@ function MonsterActions({
   return (
     <div style={{ width: '100%' }}>
       <AddMonsterAction
-        addMonsterAction={addMonsterAction}
+        addMonsterAction={addAction}
         editAction={edittingAction}
       />
       <MonsterActionsList
-        actions={actions}
-        reactions={reactions}
-        legenActions={legenActions}
-        lairActions={lairActions}
         removeAction={removeAction}
         editAction={editAction}
       />
     </div>
   );
-}
+});
 
 export default MonsterActions;

--- a/src/components/monster/monster-actions/MonsterActions.tsx
+++ b/src/components/monster/monster-actions/MonsterActions.tsx
@@ -12,18 +12,20 @@ import { connect } from 'react-redux';
 
 
 type Props = {
-  addAction: (updatedAbility: MonsterAction) => unknown;
+  addAction: (action: MonsterAction) => unknown;
+  updateAction: (action: MonsterAction) => unknown;
   removeAction: (id: string) => unknown;
 }
 
 const mapDispatch = (dispatch: Dispatch) => ({
   addAction: (action: MonsterAction) => dispatch(monster.actions.addAction(action)),
-  updateAction: (action: MonsterAction) => dispatch(monster.actions.addAction(action)),
+  updateAction: (action: MonsterAction) => dispatch(monster.actions.updateAction(action)),
   removeAction: (id: string) => dispatch(monster.actions.removeAction(id)),
 })
 
 const MonsterActions = connect(null, mapDispatch)(({
   addAction,
+  updateAction,
   removeAction,
 }: Props) => {
   const [edittingAction, setEdittingAction] = useState(null);
@@ -34,8 +36,7 @@ const MonsterActions = connect(null, mapDispatch)(({
    * an existing one
    * @param action the action we are editting
    */
-  const editAction = (action: MonsterAction, actionType: string) => {
-    action.actionType = actionType;
+  const editAction = (action: MonsterAction) => {
     setEdittingAction(action);
   };
 
@@ -43,6 +44,7 @@ const MonsterActions = connect(null, mapDispatch)(({
     <div style={{ width: '100%' }}>
       <AddMonsterAction
         addMonsterAction={addAction}
+        updateMonsterAction={updateAction}
         editAction={edittingAction}
       />
       <MonsterActionsList

--- a/src/components/monster/monster-actions/MonsterActionsList.tsx
+++ b/src/components/monster/monster-actions/MonsterActionsList.tsx
@@ -7,8 +7,7 @@ import { createStyles, List, makeStyles } from '@material-ui/core';
 import MonsterAction from '../../../models/MonsterAction';
 import MonsterActionListItem from './MonsterActionListItem';
 import { AppState } from '../../../store/store';
-import { Dispatch } from 'redux';
-import { actionsSelector, lairActionsSelector, legenActionsSelector, normActionsSelector, reactionsSelector } from '../../../selectors/monsterSelector';
+import { actionsSelector } from '../../../selectors/monsterSelector';
 import { connect } from 'react-redux';
 
 const useStyles = makeStyles(() => createStyles({

--- a/src/components/monster/monster-actions/MonsterActionsList.tsx
+++ b/src/components/monster/monster-actions/MonsterActionsList.tsx
@@ -3,16 +3,24 @@
  * Lists all the monster actions
  */
 import React from 'react';
-import { List, withStyles } from '@material-ui/core';
-import PropTypes, { InferProps } from 'prop-types';
+import { createStyles, List, makeStyles } from '@material-ui/core';
 import MonsterAction from '../../../models/MonsterAction';
 import MonsterActionListItem from './MonsterActionListItem';
 
-const useStyles = () => ({
+const useStyles = makeStyles(() => createStyles({
   list: {
     width: '100%',
   },
-});
+}));
+
+type Props = {
+  actions: Array<MonsterAction>;
+  reactions: Array<MonsterAction>;
+  legenActions: Array<MonsterAction>;
+  lairActions: Array<MonsterAction>;
+  removeAction: (id: string, actionType: string) => unknown;
+  editAction: (action: MonsterAction, actionType: string) => unknown;
+}
 
 function MonsterActionsList({
   actions,
@@ -21,8 +29,9 @@ function MonsterActionsList({
   lairActions,
   removeAction,
   editAction,
-  classes,
-}: InferProps<typeof MonsterActionsList.propTypes>) {
+}: Props) {
+  const classes = useStyles();
+
   return (
     <>
       <List className={classes.list}>
@@ -31,7 +40,7 @@ function MonsterActionsList({
             key={action.id}
             action={action}
             actionType={'Action'}
-            removeAction={removeAction}
+            removeAction={removeAction.bind(this, action, 'Action')}
             editAction={editAction.bind(this, action, 'Action')}
           />
         ))}
@@ -40,7 +49,7 @@ function MonsterActionsList({
             key={action.id}
             action={action}
             actionType={'Reaction'}
-            removeAction={removeAction}
+            removeAction={removeAction.bind(this, action, 'Reaction')}
             editAction={editAction.bind(this, action, 'Reaction')}
           />
         ))}
@@ -49,7 +58,7 @@ function MonsterActionsList({
             key={action.id}
             action={action}
             actionType={'Legendary Action'}
-            removeAction={removeAction}
+            removeAction={removeAction.bind(this, action, 'Legendary')}
             editAction={editAction.bind(this, action, 'Legendary')}
           />
         ))}
@@ -58,7 +67,7 @@ function MonsterActionsList({
             key={action.id}
             action={action}
             actionType={'Lair Action'}
-            removeAction={removeAction}
+            removeAction={removeAction.bind(this, action, 'Lair')}
             editAction={editAction.bind(this, action, 'Lair')}
           />
         ))}
@@ -67,14 +76,4 @@ function MonsterActionsList({
   );
 }
 
-MonsterActionsList.propTypes = {
-  actions: PropTypes.array.isRequired,
-  reactions: PropTypes.array.isRequired,
-  legenActions: PropTypes.array.isRequired,
-  lairActions: PropTypes.array.isRequired,
-  removeAction: PropTypes.func.isRequired,
-  editAction: PropTypes.func.isRequired,
-  classes: PropTypes.any,
-};
-
-export default withStyles(useStyles, { withTheme: true })(MonsterActionsList);
+export default MonsterActionsList;

--- a/src/components/monster/monster-actions/MonsterActionsList.tsx
+++ b/src/components/monster/monster-actions/MonsterActionsList.tsx
@@ -6,6 +6,10 @@ import React from 'react';
 import { createStyles, List, makeStyles } from '@material-ui/core';
 import MonsterAction from '../../../models/MonsterAction';
 import MonsterActionListItem from './MonsterActionListItem';
+import { AppState } from '../../../store/store';
+import { Dispatch } from 'redux';
+import { actionsSelector, lairActionsSelector, legenActionsSelector, normActionsSelector, reactionsSelector } from '../../../selectors/monsterSelector';
+import { connect } from 'react-redux';
 
 const useStyles = makeStyles(() => createStyles({
   list: {
@@ -15,21 +19,19 @@ const useStyles = makeStyles(() => createStyles({
 
 type Props = {
   actions: Array<MonsterAction>;
-  reactions: Array<MonsterAction>;
-  legenActions: Array<MonsterAction>;
-  lairActions: Array<MonsterAction>;
   removeAction: (id: string, actionType: string) => unknown;
   editAction: (action: MonsterAction, actionType: string) => unknown;
 }
 
-function MonsterActionsList({
+const mapState = (state: AppState) => ({
+  actions: actionsSelector(state),
+});
+
+const MonsterActionsList = connect(mapState)(({
   actions,
-  reactions,
-  legenActions,
-  lairActions,
   removeAction,
   editAction,
-}: Props) {
+}: Props) => {
   const classes = useStyles();
 
   return (
@@ -39,41 +41,13 @@ function MonsterActionsList({
           <MonsterActionListItem
             key={action.id}
             action={action}
-            actionType={'Action'}
             removeAction={removeAction.bind(this, action, 'Action')}
             editAction={editAction.bind(this, action, 'Action')}
-          />
-        ))}
-        {reactions.map((action: MonsterAction) => (
-          <MonsterActionListItem
-            key={action.id}
-            action={action}
-            actionType={'Reaction'}
-            removeAction={removeAction.bind(this, action, 'Reaction')}
-            editAction={editAction.bind(this, action, 'Reaction')}
-          />
-        ))}
-        {legenActions.map((action: MonsterAction) => (
-          <MonsterActionListItem
-            key={action.id}
-            action={action}
-            actionType={'Legendary Action'}
-            removeAction={removeAction.bind(this, action, 'Legendary')}
-            editAction={editAction.bind(this, action, 'Legendary')}
-          />
-        ))}
-        {lairActions.map((action: MonsterAction) => (
-          <MonsterActionListItem
-            key={action.id}
-            action={action}
-            actionType={'Lair Action'}
-            removeAction={removeAction.bind(this, action, 'Lair')}
-            editAction={editAction.bind(this, action, 'Lair')}
           />
         ))}
       </List>
     </>
   );
-}
+});
 
 export default MonsterActionsList;

--- a/src/components/monster/monster-actions/MonsterActionsList.tsx
+++ b/src/components/monster/monster-actions/MonsterActionsList.tsx
@@ -19,7 +19,7 @@ const useStyles = makeStyles(() => createStyles({
 type Props = {
   actions: Array<MonsterAction>;
   removeAction: (id: string) => unknown;
-  editAction: (action: MonsterAction, actionType: string) => unknown;
+  editAction: (action: MonsterAction) => unknown;
 }
 
 const mapState = (state: AppState) => ({
@@ -40,8 +40,8 @@ const MonsterActionsList = connect(mapState)(({
           <MonsterActionListItem
             key={action.id}
             action={action}
-            removeAction={removeAction.bind(this, action, 'Action')}
-            editAction={editAction.bind(this, action, 'Action')}
+            removeAction={removeAction}
+            editAction={editAction}
           />
         ))}
       </List>

--- a/src/components/monster/monster-actions/MonsterActionsList.tsx
+++ b/src/components/monster/monster-actions/MonsterActionsList.tsx
@@ -18,7 +18,7 @@ const useStyles = makeStyles(() => createStyles({
 
 type Props = {
   actions: Array<MonsterAction>;
-  removeAction: (id: string, actionType: string) => unknown;
+  removeAction: (id: string) => unknown;
   editAction: (action: MonsterAction, actionType: string) => unknown;
 }
 

--- a/src/components/monster/monster-descriptions/MonsterDescription.tsx
+++ b/src/components/monster/monster-descriptions/MonsterDescription.tsx
@@ -8,6 +8,8 @@
  */
 
 import React, { ChangeEvent } from 'react';
+import { Dispatch } from 'redux';
+import { connect } from 'react-redux';
 import {
   TextField,
   Theme,
@@ -16,11 +18,10 @@ import {
   InputLabel,
   MenuItem,
   FormControl,
-  withStyles,
   makeStyles,
   createStyles,
 } from '@material-ui/core';
-import PropTypes, { InferProps } from 'prop-types';
+import monster from '../../../reducers/monsterReducer';
 
 /** Setup the styling for the inputs */
 const useStyles = makeStyles((theme: Theme) => createStyles({
@@ -39,16 +40,20 @@ type Props = {
   size: string;
   type: string;
   alignment: string;
-  handleChange: (event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => void;
+  updateProperty: (property: string, value: string) => unknown;
 }
 
-function MonsterDescription({
+const mapDispatch = (dispatch: Dispatch) => ({
+  updateProperty: (property: string, value: string) => dispatch(monster.actions.updateProperty({property, value})),
+})
+
+const MonsterDescription = connect(null, mapDispatch)(({
   name,
   size,
   type,
   alignment,
-  handleChange,
-}: Props) {
+  updateProperty,
+}: Props) => {
 
   const classes = useStyles();
 
@@ -98,6 +103,11 @@ function MonsterDescription({
     'Plant',
     'Undead',
   ];
+
+  /** Update the property when there is a change */
+  const handleChange = (event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+    updateProperty(event.target.name, event.target.value);
+  }
 
   return (
     <div className={classes.descriptionRoot}>
@@ -176,6 +186,6 @@ function MonsterDescription({
       </Box>
     </div>
   );
-}
+})
 
 export default MonsterDescription;

--- a/src/components/monster/monster-descriptions/MonsterDescription.tsx
+++ b/src/components/monster/monster-descriptions/MonsterDescription.tsx
@@ -7,7 +7,7 @@
  *             Good/Evil scale
  */
 
-import React from 'react';
+import React, { ChangeEvent } from 'react';
 import {
   TextField,
   Theme,
@@ -17,11 +17,13 @@ import {
   MenuItem,
   FormControl,
   withStyles,
+  makeStyles,
+  createStyles,
 } from '@material-ui/core';
 import PropTypes, { InferProps } from 'prop-types';
 
 /** Setup the styling for the inputs */
-const useStyles = (theme: Theme) => ({
+const useStyles = makeStyles((theme: Theme) => createStyles({
   descriptionRoot: {
     width: '100%',
   },
@@ -30,7 +32,15 @@ const useStyles = (theme: Theme) => ({
     width: '50%',
     margin: theme.spacing(1),
   },
-});
+}));
+
+type Props = {
+  name: string;
+  size: string;
+  type: string;
+  alignment: string;
+  handleChange: (event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => void;
+}
 
 function MonsterDescription({
   name,
@@ -38,8 +48,10 @@ function MonsterDescription({
   type,
   alignment,
   handleChange,
-  classes,
-}: InferProps<typeof MonsterDescription.propTypes>) {
+}: Props) {
+
+  const classes = useStyles();
+
   /**
    * A list of available sizes based on the 5e sizes chart
    */
@@ -166,13 +178,4 @@ function MonsterDescription({
   );
 }
 
-MonsterDescription.propTypes = {
-  name: PropTypes.string.isRequired,
-  size: PropTypes.string.isRequired,
-  type: PropTypes.string.isRequired,
-  alignment: PropTypes.string.isRequired,
-  handleChange: PropTypes.func.isRequired,
-  classes: PropTypes.any,
-};
-
-export default withStyles(useStyles, { withTheme: true })(MonsterDescription);
+export default MonsterDescription;

--- a/src/components/monster/monster-properties/MonsterProperties.tsx
+++ b/src/components/monster/monster-properties/MonsterProperties.tsx
@@ -2,7 +2,7 @@
  * MonsterProperties.tsx
  * Handles the monster's properties.
  */
-import React from 'react';
+import React, { ChangeEvent } from 'react';
 import {
   TextField,
   withStyles,
@@ -12,12 +12,14 @@ import {
   Select,
   MenuItem,
   Box,
+  createStyles,
+  makeStyles,
 } from '@material-ui/core';
 import PropTypes, { InferProps } from 'prop-types';
 import { getDamageTypes } from '../../../hooks/getDamageTypes';
 
 /** Setup the styling for these inputs */
-const useStyles = (theme: Theme) => ({
+const useStyles = makeStyles((theme: Theme) => createStyles({
   descriptionRoot: {
     width: '100%',
   },
@@ -53,10 +55,20 @@ const useStyles = (theme: Theme) => ({
       width: '100%',
     },
   },
-});
+}));
+
+type Props = {
+  immunities: Array<string>;
+  resistances: Array<string>;
+  weaknesses: Array<string>;
+  condImmunities: Array<string>;
+  languages: Array<string>;
+  challengeRating: string;
+  rewardXP: string;
+  handleChange: (event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => void;
+}
 
 function MonsterProperties({
-  classes,
   immunities,
   resistances,
   weaknesses,
@@ -65,7 +77,10 @@ function MonsterProperties({
   challengeRating,
   rewardXP,
   handleChange,
-}: InferProps<typeof MonsterProperties.propTypes>) {
+}: Props) {
+
+  const classes = useStyles();
+
   /**
    * A list of available damage types in 5e
    */
@@ -225,16 +240,4 @@ function MonsterProperties({
   );
 }
 
-MonsterProperties.propTypes = {
-  immunities: PropTypes.array.isRequired,
-  condImmunities: PropTypes.array.isRequired,
-  resistances: PropTypes.array.isRequired,
-  weaknesses: PropTypes.array.isRequired,
-  languages: PropTypes.array.isRequired,
-  challengeRating: PropTypes.string.isRequired,
-  rewardXP: PropTypes.string.isRequired,
-  handleChange: PropTypes.func.isRequired,
-  classes: PropTypes.any,
-};
-
-export default withStyles(useStyles, { withTheme: true })(MonsterProperties);
+export default MonsterProperties;

--- a/src/components/monster/monster-properties/MonsterProperties.tsx
+++ b/src/components/monster/monster-properties/MonsterProperties.tsx
@@ -3,9 +3,10 @@
  * Handles the monster's properties.
  */
 import React, { ChangeEvent } from 'react';
+import { Dispatch } from 'redux';
+import { connect } from 'react-redux';
 import {
   TextField,
-  withStyles,
   Theme,
   InputLabel,
   FormControl,
@@ -15,8 +16,9 @@ import {
   createStyles,
   makeStyles,
 } from '@material-ui/core';
-import PropTypes, { InferProps } from 'prop-types';
 import { getDamageTypes } from '../../../hooks/getDamageTypes';
+import monster from '../../../reducers/monsterReducer';
+
 
 /** Setup the styling for these inputs */
 const useStyles = makeStyles((theme: Theme) => createStyles({
@@ -65,10 +67,15 @@ type Props = {
   languages: Array<string>;
   challengeRating: string;
   rewardXP: string;
-  handleChange: (event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => void;
+  updateProperty: (property: string, value: string) => unknown;
 }
 
-function MonsterProperties({
+const mapDispatch = (dispatch: Dispatch) => ({
+  updateProperty: (property: string, value: string) => dispatch(monster.actions.updateProperty({property, value})),
+})
+
+
+const MonsterProperties = connect(null, mapDispatch)(({
   immunities,
   resistances,
   weaknesses,
@@ -76,8 +83,8 @@ function MonsterProperties({
   languages,
   challengeRating,
   rewardXP,
-  handleChange,
-}: Props) {
+  updateProperty,
+}: Props) => {
 
   const classes = useStyles();
 
@@ -127,6 +134,10 @@ function MonsterProperties({
     'Sylvan',
     'Undercommon',
   ];
+
+  const handleChange = (event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+    updateProperty(event.target.name, event.target.value);
+  }
 
   return (
     <div className={classes.descriptionRoot}>
@@ -238,6 +249,6 @@ function MonsterProperties({
       </Box>
     </div>
   );
-}
+});
 
 export default MonsterProperties;

--- a/src/components/monster/monster-senses/MonsterSenses.tsx
+++ b/src/components/monster/monster-senses/MonsterSenses.tsx
@@ -5,8 +5,7 @@ import {
   Switch,
   TextField,
 } from '@material-ui/core';
-import propTypes, { InferProps } from 'prop-types';
-import React, { useEffect, useState } from 'react';
+import React, { ChangeEvent, useEffect, useState } from 'react';
 
 const useStyles = makeStyles(() => ({
   senseToggle: {
@@ -16,13 +15,21 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
+type Props = {
+  blindsight: string;
+  darkvision: string;
+  tremorsense: string;
+  truesight: string;
+  handleChange: (event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => void;
+}
+
 function MonsterSenses({
   blindsight,
   darkvision,
   tremorsense,
   truesight,
   handleChange,
-}: InferProps<typeof MonsterSenses.propTypes>) {
+}: Props) {
   const [hasBlind, setHasBlind] = useState(blindsight !== '');
   const [hasDark, setHasDark] = useState(darkvision !== '');
   const [hasTremor, setHasTremor] = useState(tremorsense != '');
@@ -37,42 +44,42 @@ function MonsterSenses({
 
   /** Setup the effect to toggle if blindsight is available or not */
   useEffect(() => {
-    handleChange({
-      target: {
-        name: 'blindsight',
-        value: !hasBlind ? '' : blindsight,
-      },
-    });
+    // handleChange({
+    //   target: {
+    //     name: 'blindsight',
+    //     value: !hasBlind ? '' : blindsight,
+    //   },
+    // });
   }, [hasBlind]);
 
   /** Setup the effect to toggle if darkvision is available or not */
   useEffect(() => {
-    handleChange({
-      target: {
-        name: 'darkvision',
-        value: !hasDark ? '' : darkvision,
-      },
-    });
+    // handleChange({
+    //   target: {
+    //     name: 'darkvision',
+    //     value: !hasDark ? '' : darkvision,
+    //   },
+    // });
   }, [hasDark]);
 
   /** Setup the effect to toggle if tremorsense is available or not */
   useEffect(() => {
-    handleChange({
-      target: {
-        name: 'tremorsense',
-        value: !hasTremor ? '' : tremorsense,
-      },
-    });
+    // handleChange({
+    //   target: {
+    //     name: 'tremorsense',
+    //     value: !hasTremor ? '' : tremorsense,
+    //   },
+    // });
   }, [hasTremor]);
 
   /** Setup the effect to toggle if truesight is available or not */
   useEffect(() => {
-    handleChange({
-      target: {
-        name: 'truesight',
-        value: !hasTruesight ? '' : truesight,
-      },
-    });
+    // handleChange({
+    //   target: {
+    //     name: 'truesight',
+    //     value: !hasTruesight ? '' : truesight,
+    //   },
+    // });
   }, [hasTruesight]);
 
   // **************************************
@@ -104,7 +111,7 @@ function MonsterSenses({
    * before trying to update the state
    * @param event The event passed in from material UI onChange
    */
-  const handleIntChange = (event: { target: { name: any; value: any } }) => {
+  const handleIntChange = (event:ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
     // If it's null or a number value we will let it update the state in the parent
     if (event.target.value == null || /^-?[0-9]*$/.test(event.target.value)) {
       handleChange(event);
@@ -204,13 +211,5 @@ function MonsterSenses({
     </Box>
   );
 }
-
-MonsterSenses.propTypes = {
-  blindsight: propTypes.string,
-  darkvision: propTypes.string,
-  tremorsense: propTypes.string,
-  truesight: propTypes.string,
-  handleChange: propTypes.func,
-};
 
 export default MonsterSenses;

--- a/src/components/monster/monster-senses/MonsterSenses.tsx
+++ b/src/components/monster/monster-senses/MonsterSenses.tsx
@@ -6,6 +6,10 @@ import {
   TextField,
 } from '@material-ui/core';
 import React, { ChangeEvent, useEffect, useState } from 'react';
+import { Dispatch } from 'redux';
+import { connect } from 'react-redux';
+import monster from '../../../reducers/monsterReducer';
+
 
 const useStyles = makeStyles(() => ({
   senseToggle: {
@@ -20,16 +24,20 @@ type Props = {
   darkvision: string;
   tremorsense: string;
   truesight: string;
-  handleChange: (event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => void;
+  updateProperty: (property: string, value: string) => unknown;
 }
 
-function MonsterSenses({
+const mapDispatch = (dispatch: Dispatch) => ({
+  updateProperty: (property: string, value: string) => dispatch(monster.actions.updateProperty({property, value})),
+})
+
+const MonsterSenses = connect(null, mapDispatch)(({
   blindsight,
   darkvision,
   tremorsense,
   truesight,
-  handleChange,
-}: Props) {
+  updateProperty,
+}: Props) => {
   const [hasBlind, setHasBlind] = useState(blindsight !== '');
   const [hasDark, setHasDark] = useState(darkvision !== '');
   const [hasTremor, setHasTremor] = useState(tremorsense != '');
@@ -44,42 +52,22 @@ function MonsterSenses({
 
   /** Setup the effect to toggle if blindsight is available or not */
   useEffect(() => {
-    // handleChange({
-    //   target: {
-    //     name: 'blindsight',
-    //     value: !hasBlind ? '' : blindsight,
-    //   },
-    // });
+    updateProperty('blindsight', !hasBlind ? '' : blindsight);
   }, [hasBlind]);
 
   /** Setup the effect to toggle if darkvision is available or not */
   useEffect(() => {
-    // handleChange({
-    //   target: {
-    //     name: 'darkvision',
-    //     value: !hasDark ? '' : darkvision,
-    //   },
-    // });
+    updateProperty('darkvision', !hasDark ? '' : darkvision);
   }, [hasDark]);
 
   /** Setup the effect to toggle if tremorsense is available or not */
   useEffect(() => {
-    // handleChange({
-    //   target: {
-    //     name: 'tremorsense',
-    //     value: !hasTremor ? '' : tremorsense,
-    //   },
-    // });
+    updateProperty('tremorsense', !hasTremor ? '' : tremorsense);
   }, [hasTremor]);
 
   /** Setup the effect to toggle if truesight is available or not */
   useEffect(() => {
-    // handleChange({
-    //   target: {
-    //     name: 'truesight',
-    //     value: !hasTruesight ? '' : truesight,
-    //   },
-    // });
+    updateProperty('truesight', !hasTruesight ? '' : truesight)
   }, [hasTruesight]);
 
   // **************************************
@@ -114,7 +102,7 @@ function MonsterSenses({
   const handleIntChange = (event:ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
     // If it's null or a number value we will let it update the state in the parent
     if (event.target.value == null || /^-?[0-9]*$/.test(event.target.value)) {
-      handleChange(event);
+      updateProperty(event.target.name, event.target.value);
     }
   };
 
@@ -210,6 +198,6 @@ function MonsterSenses({
       </Box>
     </Box>
   );
-}
+});
 
 export default MonsterSenses;

--- a/src/components/monster/monster-speed/MonsterSpeed.tsx
+++ b/src/components/monster/monster-speed/MonsterSpeed.tsx
@@ -1,4 +1,7 @@
 import React, { ChangeEvent, useEffect, useState } from 'react';
+import { Dispatch } from 'redux';
+import { connect } from 'react-redux';
+import monster from '../../../reducers/monsterReducer';
 import {
   Box,
   FormControlLabel,
@@ -21,17 +24,21 @@ type Props = {
   burrowSpeed: string;
   climbSpeed: string;
   hoverSpeed: string;
-  handleChange: (event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => void;
+  updateProperty: (property: string, value: string) => unknown;
 };
 
-function MonsterSpeed({
+const mapDispatch = (dispatch: Dispatch) => ({
+  updateProperty: (property: string, value: string) => dispatch(monster.actions.updateProperty({property, value})),
+})
+
+const MonsterSpeed = connect(null, mapDispatch)(({
   landSpeed,
   flySpeed,
   burrowSpeed,
   climbSpeed,
   hoverSpeed,
-  handleChange,
-}: Props) {
+  updateProperty,
+}: Props) => {
   const [hasLand, setHasLand] = useState(landSpeed !== '');
   const [hasFly, setHasFly] = useState(flySpeed !== '');
   const [hasBurrow, setHasBurrow] = useState(burrowSpeed !== '');
@@ -47,52 +54,27 @@ function MonsterSpeed({
 
   /** Setup the effect to toggle the requirements for land speed */
   useEffect(() => {
-    // handleChange({
-    //   target: {
-    //     name: 'landSpeed',
-    //     value: !hasLand ? '' : landSpeed,
-    //   },
-    // }) as HTMLInputElement;
+    updateProperty('landSpeed', !hasLand ? '' : landSpeed);
   }, [hasLand]);
 
   /** Setup the effect to toggle the requirements for fly speed */
   useEffect(() => {
-    // handleChange({
-    //   target: {
-    //     name: 'flySpeed',
-    //     value: !hasFly ? '' : flySpeed,
-    //   },
-    // });
+    updateProperty('flySpeed', !hasFly ? '' : flySpeed);
   }, [hasFly]);
 
   /** Setup the effect to toggle the requirements for burrow speed */
   useEffect(() => {
-    // handleChange({
-    //   target: {
-    //     name: 'burrowSpeed',
-    //     value: !hasBurrow ? '' : burrowSpeed,
-    //   },
-    // });
+    updateProperty('burrowSpeed', !hasBurrow ? '' : burrowSpeed);
   }, [hasBurrow]);
 
   /** Setup the effect to toggle the requirements for climb speed */
   useEffect(() => {
-    // handleChange({
-    //   target: {
-    //     name: 'climbSpeed',
-    //     value: !hasClimb ? '' : climbSpeed,
-    //   },
-    // });
+    updateProperty('climbSpeed', !hasClimb ? '' : climbSpeed);
   }, [hasClimb]);
 
   /** Setup the effect to toggle the requirements for hover speed */
   useEffect(() => {
-    // handleChange({
-    //   target: {
-    //     name: 'hasHover',
-    //     value: !hasHover ? '' : hoverSpeed,
-    //   },
-    // });
+    updateProperty('hoverSpeed', !hasHover ? '' : hoverSpeed);
   }, [hasHover]);
 
   // **************************************
@@ -133,7 +115,7 @@ function MonsterSpeed({
   const handleIntChange = (event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
     // If it's null or a number value we will let it update the state in the parent
     if (event.target.value == null || /^-?[0-9]*$/.test(event.target.value)) {
-      handleChange(event);
+      updateProperty(event.target.name, event.target.value);
     }
   };
 
@@ -251,6 +233,6 @@ function MonsterSpeed({
       </Box>
     </Box>
   );
-}
+});
 
 export default MonsterSpeed;

--- a/src/components/monster/monster-speed/MonsterSpeed.tsx
+++ b/src/components/monster/monster-speed/MonsterSpeed.tsx
@@ -1,5 +1,4 @@
-import React, { useEffect, useState } from 'react';
-import propTypes, { InferProps } from 'prop-types';
+import React, { ChangeEvent, useEffect, useState } from 'react';
 import {
   Box,
   FormControlLabel,
@@ -16,6 +15,15 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
+type Props = {
+  landSpeed: string;
+  flySpeed: string;
+  burrowSpeed: string;
+  climbSpeed: string;
+  hoverSpeed: string;
+  handleChange: (event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => void;
+};
+
 function MonsterSpeed({
   landSpeed,
   flySpeed,
@@ -23,7 +31,7 @@ function MonsterSpeed({
   climbSpeed,
   hoverSpeed,
   handleChange,
-}: InferProps<typeof MonsterSpeed.propTypes>) {
+}: Props) {
   const [hasLand, setHasLand] = useState(landSpeed !== '');
   const [hasFly, setHasFly] = useState(flySpeed !== '');
   const [hasBurrow, setHasBurrow] = useState(burrowSpeed !== '');
@@ -39,52 +47,52 @@ function MonsterSpeed({
 
   /** Setup the effect to toggle the requirements for land speed */
   useEffect(() => {
-    handleChange({
-      target: {
-        name: 'landSpeed',
-        value: !hasLand ? '' : landSpeed,
-      },
-    });
+    // handleChange({
+    //   target: {
+    //     name: 'landSpeed',
+    //     value: !hasLand ? '' : landSpeed,
+    //   },
+    // }) as HTMLInputElement;
   }, [hasLand]);
 
   /** Setup the effect to toggle the requirements for fly speed */
   useEffect(() => {
-    handleChange({
-      target: {
-        name: 'flySpeed',
-        value: !hasFly ? '' : flySpeed,
-      },
-    });
+    // handleChange({
+    //   target: {
+    //     name: 'flySpeed',
+    //     value: !hasFly ? '' : flySpeed,
+    //   },
+    // });
   }, [hasFly]);
 
   /** Setup the effect to toggle the requirements for burrow speed */
   useEffect(() => {
-    handleChange({
-      target: {
-        name: 'burrowSpeed',
-        value: !hasBurrow ? '' : burrowSpeed,
-      },
-    });
+    // handleChange({
+    //   target: {
+    //     name: 'burrowSpeed',
+    //     value: !hasBurrow ? '' : burrowSpeed,
+    //   },
+    // });
   }, [hasBurrow]);
 
   /** Setup the effect to toggle the requirements for climb speed */
   useEffect(() => {
-    handleChange({
-      target: {
-        name: 'climbSpeed',
-        value: !hasClimb ? '' : climbSpeed,
-      },
-    });
+    // handleChange({
+    //   target: {
+    //     name: 'climbSpeed',
+    //     value: !hasClimb ? '' : climbSpeed,
+    //   },
+    // });
   }, [hasClimb]);
 
   /** Setup the effect to toggle the requirements for hover speed */
   useEffect(() => {
-    handleChange({
-      target: {
-        name: 'hasHover',
-        value: !hasHover ? '' : hoverSpeed,
-      },
-    });
+    // handleChange({
+    //   target: {
+    //     name: 'hasHover',
+    //     value: !hasHover ? '' : hoverSpeed,
+    //   },
+    // });
   }, [hasHover]);
 
   // **************************************
@@ -122,7 +130,7 @@ function MonsterSpeed({
    * before trying to update the state
    * @param event The event passed in from material UI onChange
    */
-  const handleIntChange = (event: { target: { name: any; value: any } }) => {
+  const handleIntChange = (event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
     // If it's null or a number value we will let it update the state in the parent
     if (event.target.value == null || /^-?[0-9]*$/.test(event.target.value)) {
       handleChange(event);
@@ -244,14 +252,5 @@ function MonsterSpeed({
     </Box>
   );
 }
-
-MonsterSpeed.propTypes = {
-  landSpeed: propTypes.string,
-  flySpeed: propTypes.string,
-  burrowSpeed: propTypes.string,
-  climbSpeed: propTypes.string,
-  hoverSpeed: propTypes.string,
-  handleChange: propTypes.func,
-};
 
 export default MonsterSpeed;

--- a/src/components/monster/monster-stats/MonsterStats.tsx
+++ b/src/components/monster/monster-stats/MonsterStats.tsx
@@ -19,6 +19,9 @@ import {
   createStyles,
 } from '@material-ui/core';
 import { getStats, getProficiencies } from '../../../hooks/getTypeMaps';
+import { Dispatch } from 'redux';
+import { connect } from 'react-redux';
+import monster from '../../../reducers/monsterReducer';
 
 /** Setup the styling for these inputs */
 const useStyles =  makeStyles((theme: Theme) => createStyles({
@@ -95,10 +98,15 @@ type Props = {
   proficiencies: Array<string>;
   savingThrows: Array<string>;
   hitDie: string;
-  handleChange: (event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => void;
+  updateProperty: (property: string, value: string) => unknown;
 };
 
-function MonsterStats({
+const mapDispatch = (dispatch: Dispatch) => ({
+  updateProperty: (property: string, value: string) => dispatch(monster.actions.updateProperty({property, value})),
+})
+
+
+const MonsterStats = connect(null, mapDispatch)(({
   armourClass,
   hitPoints,
   str,
@@ -111,12 +119,20 @@ function MonsterStats({
   proficiencies,
   savingThrows,
   hitDie,
-  handleChange,
-}: Props) {
+  updateProperty,
+}: Props) => {
   const classes = useStyles();
 
   const availableProfs: object = getProficiencies();
   const availableSavingThrows: object = getStats();
+
+  /** 
+   * Handles the basic change of an input change 
+   * @param event the event passed in from the material UI onChange event
+   */
+  const handleChange = (event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+    updateProperty(event.target.name, event.target.value);
+  }
 
   /**
    * Takes an input event and checks to see if it was an integer input
@@ -126,7 +142,7 @@ function MonsterStats({
   const handleIntChange = (event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
     // If it's null or a number value we will let it update the state in the parent
     if (event.target.value == null || /^-?[0-9]*$/.test(event.target.value)) {
-      handleChange(event);
+      updateProperty(event.target.name, event.target.value);
     }
   };
 
@@ -257,6 +273,6 @@ function MonsterStats({
       </Box>
     </div>
   );
-}
+});
 
 export default MonsterStats;

--- a/src/components/monster/monster-stats/MonsterStats.tsx
+++ b/src/components/monster/monster-stats/MonsterStats.tsx
@@ -6,22 +6,22 @@
  * like, so I made a work around making it so only numbers can be put
  * in normal textfields which forces the types to have to be strings
  */
-import React from 'react';
+import React, { ChangeEvent } from 'react';
 import {
   TextField,
   Box,
   Theme,
-  withStyles,
   FormControl,
   InputLabel,
   Select,
   MenuItem,
+  makeStyles,
+  createStyles,
 } from '@material-ui/core';
 import { getStats, getProficiencies } from '../../../hooks/getTypeMaps';
-import PropTypes, { InferProps } from 'prop-types';
 
 /** Setup the styling for these inputs */
-const useStyles = (theme: Theme) => ({
+const useStyles =  makeStyles((theme: Theme) => createStyles({
   descriptionRoot: {
     width: '100%',
   },
@@ -80,10 +80,25 @@ const useStyles = (theme: Theme) => ({
       width: '100%',
     },
   },
-});
+}));
+
+type Props = {
+  armourClass: string;
+  hitPoints: string;
+  str: string;
+  dex: string;
+  con: string;
+  int: string;
+  wis: string;
+  chr: string;
+  profBonus: string;
+  proficiencies: Array<string>;
+  savingThrows: Array<string>;
+  hitDie: string;
+  handleChange: (event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => void;
+};
 
 function MonsterStats({
-  classes,
   armourClass,
   hitPoints,
   str,
@@ -97,7 +112,9 @@ function MonsterStats({
   savingThrows,
   hitDie,
   handleChange,
-}: InferProps<typeof MonsterStats.propTypes>) {
+}: Props) {
+  const classes = useStyles();
+
   const availableProfs: object = getProficiencies();
   const availableSavingThrows: object = getStats();
 
@@ -106,7 +123,7 @@ function MonsterStats({
    * before trying to update the state
    * @param event The event passed in from material UI onChange
    */
-  const handleIntChange = (event: { target: { name: any; value: any } }) => {
+  const handleIntChange = (event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
     // If it's null or a number value we will let it update the state in the parent
     if (event.target.value == null || /^-?[0-9]*$/.test(event.target.value)) {
       handleChange(event);
@@ -242,21 +259,4 @@ function MonsterStats({
   );
 }
 
-MonsterStats.propTypes = {
-  armourClass: PropTypes.string.isRequired,
-  hitPoints: PropTypes.string.isRequired,
-  str: PropTypes.string.isRequired,
-  dex: PropTypes.string.isRequired,
-  con: PropTypes.string.isRequired,
-  int: PropTypes.string.isRequired,
-  wis: PropTypes.string.isRequired,
-  chr: PropTypes.string.isRequired,
-  profBonus: PropTypes.string.isRequired,
-  hitDie: PropTypes.string.isRequired,
-  proficiencies: PropTypes.array.isRequired,
-  savingThrows: PropTypes.array.isRequired,
-  handleChange: PropTypes.func.isRequired,
-  classes: PropTypes.any,
-};
-
-export default withStyles(useStyles, { withTheme: true })(MonsterStats);
+export default MonsterStats;

--- a/src/components/monster/stat-block/FormattedAction.tsx
+++ b/src/components/monster/stat-block/FormattedAction.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import MonsterAction from '../../../models/MonsterAction';
-import PropTypes, { InferProps } from 'prop-types';
 
-function FormattedAction({ action }: InferProps<typeof FormattedAction.propTypes>) {
+type Props = {
+  action: MonsterAction
+}
+
+function FormattedAction({ action }: Props) {
   return (
     <div style={{ fontSize: '13px', paddingBottom: '4px' }}>
       <strong>{action.name}.</strong>{' '}
@@ -16,9 +19,5 @@ function FormattedAction({ action }: InferProps<typeof FormattedAction.propTypes
     </div>
   );
 }
-
-FormattedAction.propTypes = {
-  action: PropTypes.instanceOf(MonsterAction).isRequired,
-};
 
 export default FormattedAction;

--- a/src/components/monster/stat-block/SpeedFormat.tsx
+++ b/src/components/monster/stat-block/SpeedFormat.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
-import propTypes, { InferProps } from 'prop-types';
+
+type Props = {
+  landSpeed: string;
+  flySpeed: string;
+  burrowSpeed: string;
+  climbSpeed: string;
+  hoverSpeed: string;
+}
 
 function SpeedFormat({
   landSpeed,
@@ -7,7 +14,7 @@ function SpeedFormat({
   burrowSpeed,
   climbSpeed,
   hoverSpeed,
-}: InferProps<typeof SpeedFormat.propTypes>) {
+}: Props) {
   return (
     <span>
       {landSpeed && parseInt(landSpeed) > 0 && <>{landSpeed}ft. </>}
@@ -19,12 +26,5 @@ function SpeedFormat({
   );
 }
 
-SpeedFormat.propTypes = {
-  landSpeed: propTypes.string,
-  flySpeed: propTypes.string,
-  burrowSpeed: propTypes.string,
-  climbSpeed: propTypes.string,
-  hoverSpeed: propTypes.string,
-};
 
 export default SpeedFormat;

--- a/src/components/monster/stat-block/StatBlock.tsx
+++ b/src/components/monster/stat-block/StatBlock.tsx
@@ -352,7 +352,7 @@ const StatBlock = connect(mapState)(({
               ))}
             </div>
           )}
-          {monster.reactions.length > 0 && (
+          {/* {monster.reactions.length > 0 && (
             <div className={classes.actionContainer}>
               <div className={`${classes.actionTypeHeader} ${classes.accentColour}`}>
                 Reactions
@@ -390,7 +390,7 @@ const StatBlock = connect(mapState)(({
                 <FormattedAction key={`formatted-${action.id}`} action={action} />
               ))}
             </div>
-          )}
+          )} */}
         </div>
         <StatBlockBorder />
       </div>

--- a/src/components/monster/stat-block/StatBlock.tsx
+++ b/src/components/monster/stat-block/StatBlock.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes, { InferProps } from 'prop-types';
-import { withStyles, createStyles, Box } from '@material-ui/core';
+import { withStyles, createStyles, Box, StyleRules, makeStyles, Theme } from '@material-ui/core';
 import SectionSeparator from './SectionSeparator';
 import StatBlockBorder from './StatBlockBorder';
 import SpeedFormat from './SpeedFormat';
@@ -11,9 +11,9 @@ import { getProfModifier } from '../../../hooks/getProfModifier';
 import FormattedAction from './FormattedAction';
 import MonsterAbility from '../../../models/MonsterAbility';
 import MonsterAction from '../../../models/MonsterAction';
+import MonsterDefinition from '../../../models/MonsterDefinition';
 
-const useStyles = () =>
-  createStyles({
+const useStyles = makeStyles(() => createStyles({
     root: {
       fontFamily: 'Arial, Helvetica, sans-serif',
       paddingLeft: '16px',
@@ -89,14 +89,22 @@ const useStyles = () =>
     firstSectionContainer: {
       display:'inline-block'
     }
-  });
+  }));
+
+type Props = {
+  monster: MonsterDefinition;
+  twoColumns: boolean;
+  saveRef: React.MutableRefObject<undefined>;
+};
 
 function StatBlock({
   monster,
   twoColumns,
   saveRef,
-  classes,
-}: InferProps<typeof StatBlock.propTypes>) {
+}: Props) {
+
+  const classes = useStyles();
+
   /**
    * Calculates the passive perception. This is calculated from
    * 10 + proficiency bonus + perception.
@@ -384,11 +392,4 @@ function StatBlock({
   );
 }
 
-StatBlock.propTypes = {
-  monster: PropTypes.any.isRequired,
-  twoColumns: PropTypes.bool.isRequired,
-  saveRef: PropTypes.any,
-  classes: PropTypes.any,
-};
-
-export default withStyles(useStyles, { withTheme: true })(StatBlock);
+export default StatBlock;

--- a/src/components/monster/stat-block/StatBlock.tsx
+++ b/src/components/monster/stat-block/StatBlock.tsx
@@ -10,10 +10,10 @@ import { getProfModifier } from '../../../hooks/getProfModifier';
 import FormattedAction from './FormattedAction';
 import MonsterAbility from '../../../models/MonsterAbility';
 import MonsterAction from '../../../models/MonsterAction';
-import MonsterDefinition from '../../../models/MonsterDefinition';
 import { lairActionsSelector, legenActionsSelector, monsterSelector, normActionsSelector, reactionsSelector } from '../../../selectors/monsterSelector';
 import { connect } from 'react-redux';
 import { AppState } from '../../../store/store';
+import { MonsterType } from '../../../models/MonsterDefinition';
 
 const useStyles = makeStyles(() => createStyles({
     root: {
@@ -95,7 +95,7 @@ const useStyles = makeStyles(() => createStyles({
   }));
 
 type Props = {
-  monster: MonsterDefinition;
+  monster: MonsterType;
   actions: Array<MonsterAction>;
   reactions: Array<MonsterAction>;
   legenActions: Array<MonsterAction>;

--- a/src/components/monster/stat-block/StatBlock.tsx
+++ b/src/components/monster/stat-block/StatBlock.tsx
@@ -11,7 +11,7 @@ import FormattedAction from './FormattedAction';
 import MonsterAbility from '../../../models/MonsterAbility';
 import MonsterAction from '../../../models/MonsterAction';
 import MonsterDefinition from '../../../models/MonsterDefinition';
-import { monsterSelector } from '../../../selectors/monsterSelector';
+import { lairActionsSelector, legenActionsSelector, monsterSelector, normActionsSelector, reactionsSelector } from '../../../selectors/monsterSelector';
 import { connect } from 'react-redux';
 import { AppState } from '../../../store/store';
 
@@ -68,6 +68,7 @@ const useStyles = makeStyles(() => createStyles({
     },
     actionContainer: {
       display: 'inline-block',
+      width: '100%',
     },
     stats: {
       fontSize: '15px',
@@ -95,16 +96,28 @@ const useStyles = makeStyles(() => createStyles({
 
 type Props = {
   monster: MonsterDefinition;
+  actions: Array<MonsterAction>;
+  reactions: Array<MonsterAction>;
+  legenActions: Array<MonsterAction>;
+  lairActions: Array<MonsterAction>;
   twoColumns: boolean;
   saveRef: React.MutableRefObject<undefined>;
 };
 
 const mapState = (state: AppState) => ({
   monster: monsterSelector(state),
+  actions: normActionsSelector(state),
+  reactions: reactionsSelector(state),
+  legenActions: legenActionsSelector(state),
+  lairActions: lairActionsSelector(state),
 });
 
 const StatBlock = connect(mapState)(({
   monster,
+  actions,
+  reactions,
+  legenActions,
+  lairActions,
   twoColumns,
   saveRef,
 }: Props) => {
@@ -341,29 +354,29 @@ const StatBlock = connect(mapState)(({
               );
             })}
           </div>
-          {monster.actions.length > 0 && (
+          {actions.length > 0 && (
             <div className={classes.actionContainer}>
               <div className={`${classes.actionTypeHeader} ${classes.accentColour}`}>
                 Actions
               </div>
               <hr className={classes.titleUnderline} />
-              {monster.actions.map((action: MonsterAction) => (
+              {actions.map((action: MonsterAction) => (
                 <FormattedAction key={`formatted-${action.id}`} action={action} />
               ))}
             </div>
           )}
-          {/* {monster.reactions.length > 0 && (
+          {reactions.length > 0 && (
             <div className={classes.actionContainer}>
               <div className={`${classes.actionTypeHeader} ${classes.accentColour}`}>
                 Reactions
               </div>
               <hr className={classes.titleUnderline} />
-              {monster.reactions.map((action: MonsterAction) => (
+              {reactions.map((action: MonsterAction) => (
                 <FormattedAction key={`formatted-${action.id}`} action={action} />
               ))}
             </div>
           )}
-          {monster.legenActions.length > 0 && (
+          {legenActions.length > 0 && (
             <div className={classes.actionContainer}>
               <div className={`${classes.actionTypeHeader} ${classes.accentColour}`}>
                 Legendary Actions
@@ -375,22 +388,22 @@ const StatBlock = connect(mapState)(({
                 only at the end of another creature's turn. Spent legendary Actions
                 are regained at the start of each turn.
               </p>
-              {monster.legenActions.map((action: MonsterAction) => (
+              {legenActions.map((action: MonsterAction) => (
                 <FormattedAction key={`formatted-${action.id}`} action={action} />
               ))}
             </div>
           )}
-          {monster.lairActions.length > 0 && (
+          {lairActions.length > 0 && (
             <div className={classes.actionContainer}>
               <div className={`${classes.actionTypeHeader} ${classes.accentColour}`}>
                 Lair Actions
               </div>
               <hr className={classes.titleUnderline} />
-              {monster.lairActions.map((action: MonsterAction) => (
+              {lairActions.map((action: MonsterAction) => (
                 <FormattedAction key={`formatted-${action.id}`} action={action} />
               ))}
             </div>
-          )} */}
+          )}
         </div>
         <StatBlockBorder />
       </div>

--- a/src/components/monster/stat-block/StatBlock.tsx
+++ b/src/components/monster/stat-block/StatBlock.tsx
@@ -11,6 +11,9 @@ import FormattedAction from './FormattedAction';
 import MonsterAbility from '../../../models/MonsterAbility';
 import MonsterAction from '../../../models/MonsterAction';
 import MonsterDefinition from '../../../models/MonsterDefinition';
+import { monsterSelector } from '../../../selectors/monsterSelector';
+import { connect } from 'react-redux';
+import { AppState } from '../../../store/store';
 
 const useStyles = makeStyles(() => createStyles({
     root: {
@@ -96,11 +99,15 @@ type Props = {
   saveRef: React.MutableRefObject<undefined>;
 };
 
-function StatBlock({
+const mapState = (state: AppState) => ({
+  monster: monsterSelector(state),
+});
+
+const StatBlock = connect(mapState)(({
   monster,
   twoColumns,
   saveRef,
-}: Props) {
+}: Props) => {
 
   const classes = useStyles();
 
@@ -389,6 +396,6 @@ function StatBlock({
       </div>
     </div>
   );
-}
+})
 
 export default StatBlock;

--- a/src/components/monster/stat-block/StatBlock.tsx
+++ b/src/components/monster/stat-block/StatBlock.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import PropTypes, { InferProps } from 'prop-types';
-import { withStyles, createStyles, Box, StyleRules, makeStyles, Theme } from '@material-ui/core';
+import { createStyles, Box, makeStyles } from '@material-ui/core';
 import SectionSeparator from './SectionSeparator';
 import StatBlockBorder from './StatBlockBorder';
 import SpeedFormat from './SpeedFormat';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import { Provider } from "react-redux";
 import ReactDOM from 'react-dom';
 import App from './App';
+import { makeStore } from './store/store';
 
-ReactDOM.render(<App />, document.getElementById('output'));
+ReactDOM.render(<Provider store={makeStore()}><App /></Provider>, document.getElementById('output'));

--- a/src/models/MonsterAbility.tsx
+++ b/src/models/MonsterAbility.tsx
@@ -1,11 +1,11 @@
-import { v4 as uuidv4 } from 'uuid';
-
-export default class MonsterAbility {
-  public id: string = uuidv4();
-  public name: string = '';
-  public description: string = '';
-
-  constructor(init?: Partial<MonsterAbility>) {
-    Object.assign(this, init);
-  }
+/**
+ * The structure of a monster ability
+ */
+type MonsterAbility = {
+  id: string;
+  name: string;
+  description: string;
 }
+
+
+export default MonsterAbility;

--- a/src/models/MonsterAction.tsx
+++ b/src/models/MonsterAction.tsx
@@ -1,18 +1,15 @@
-import { v4 as uuidv4 } from 'uuid';
-
-export default class MonsterAction {
-  public id: string = uuidv4();
-  public name: string = '';
-  public description: string = '';
-  public actionType: string = '';
-  public isAttack: boolean = false;
-  public attackType?: string;
-  public toHit?: string;
-  public damage?: string;
-  public damageType?: string;
-  public reach?: string;
-
-  constructor(init?: Partial<MonsterAction>) {
-    Object.assign(this, init);
-  }
+type MonsterAction = {
+  id: string;
+  name: string;
+  description: string;
+  actionType: string;
+  isAttack: boolean;
+  attackType: string;
+  toHit: string;
+  damage: string;
+  damageType: string;
+  reach: string;
 }
+
+
+export default MonsterAction;

--- a/src/models/MonsterDefinition.tsx
+++ b/src/models/MonsterDefinition.tsx
@@ -1,3 +1,4 @@
+import { v4 } from 'uuid';
 import MonsterAbility from './MonsterAbility';
 import MonsterAction from './MonsterAction';
 
@@ -9,6 +10,228 @@ import MonsterAction from './MonsterAction';
  * like, so I made a work around making it so only numbers can be put
  * in normal textfields which forces the types to have to be strings
  */
+export type MonsterType = {
+  name: string;
+  size: string;
+  type: string;
+  alignment: string;
+  armourClass: string;
+  hitPoints: string;
+  hitDie: string;
+  landSpeed: string;
+  flySpeed: string;
+  burrowSpeed: string;
+  climbSpeed: string;
+  hoverSpeed: string;
+  str: string;
+  dex: string;
+  con: string;
+  int: string;
+  wis: string;
+  chr: string;
+  blindsight: string;
+  darkvision: string;
+  tremorsense: string;
+  truesight: string;
+  profBonus: string;
+  challengeRating: string;
+  rewardXP: string;
+  proficiencies: Array<string>;
+  savingThrows: Array<string>;
+  immunities: Array<string>;
+  condImmunities: Array<string>;
+  resistances: Array<string>;
+  weaknesses: Array<string>;
+  languages: Array<string>;
+  abilities: Array<MonsterAbility>;
+  actions: Array<MonsterAction>;
+  legenActions: Array<MonsterAction>;
+  reactions: Array<MonsterAction>;
+  lairActions: Array<MonsterAction>;
+}
+
+/** Creates an empty monster */
+export const newMonster = (): MonsterType => ({
+  name: '',
+  size: '',
+  type: '',
+  alignment: '',
+  armourClass: '',
+  hitPoints: '',
+  hitDie: '',
+  landSpeed: '',
+  flySpeed: '',
+  burrowSpeed: '',
+  climbSpeed: '',
+  hoverSpeed: '',
+  str: '0',
+  dex: '0',
+  con: '0',
+  int: '0',
+  wis: '0',
+  chr: '0',
+  blindsight: '',
+  darkvision: '',
+  tremorsense: '',
+  truesight: '',
+  profBonus: '0',
+  challengeRating: '',
+  rewardXP: '',
+  proficiencies: new Array<string>(),
+  savingThrows: new Array<string>(),
+  immunities: new Array<string>(),
+  condImmunities: new Array<string>(),
+  resistances: new Array<string>(),
+  weaknesses: new Array<string>(),
+  languages: new Array<string>(),
+  abilities: new Array<MonsterAbility>(),
+  actions: new Array<MonsterAction>(),
+  legenActions: new Array<MonsterAction>(),
+  reactions: new Array<MonsterAction>(),
+  lairActions: new Array<MonsterAction>(),
+});
+
+/**
+ * Generates an example monster based off the 5e lich which can be located
+ * https://roll20.net/compendium/dnd5e/Lich
+ */
+export const exampleMonster = (): MonsterType => ({
+  name: 'Lich',
+  size: 'Medium',
+  type: 'Undead',
+  alignment: 'Neutral Evil',
+  armourClass: '17',
+  hitPoints: '135',
+  hitDie: '18d8+54',
+  landSpeed: '30',
+  flySpeed: '',
+  burrowSpeed: '',
+  climbSpeed: '',
+  hoverSpeed: '',
+  str: '11',
+  dex: '16',
+  con: '16',
+  int: '20',
+  wis: '14',
+  chr: '16',
+  blindsight: '',
+  darkvision: '',
+  tremorsense: '',
+  truesight: '120',
+  profBonus: '7',
+  challengeRating: '21',
+  rewardXP: '33000',
+  proficiencies: ['arc', 'hst', 'ins', 'per'],
+  savingThrows: ['con', 'int', 'wis'],
+  immunities:  ['Poison', 'Bludgeoning', 'Piercing', 'Slashing'],
+  condImmunities:  [
+    'Charmed',
+    'Exhaustion',
+    'Frightenened',
+    'Paralyzed',
+    'Poisoned',
+  ],
+  resistances: ['Cold', 'Lightning', 'Necrotic'],
+  weaknesses: new Array<string>(),
+  languages: ['Common', 'Elvish', 'Celestial', 'Sylvan', 'Primordial'],
+  abilities: [
+    {
+      id: v4(),
+      name: 'Legendary Resistance (3/Day)',
+      description:
+        'If the lich fails a saving throw, it can choose to succeed instead.',
+    },
+    {
+      id: v4(),
+      name: 'Rejuvenation',
+      description:
+        'If it has a phylactery, a destroyed lich gains a new body in 1d10 ' +
+        'days, regaining all its hit points and becoming active again. The ' +
+        'new body appears within 5 feet of the phylactery.',
+    },
+    {
+      id: v4(),
+      name: 'Spellcasting',
+      description:
+        'The lich is an 18th-level spellcaster. Its spellcasting ability is ' +
+        'Intelligence (spell save DC 20, +12 to hit with spell attacks). ' +
+        'The lich has the following wizard spells prepared: \n' +
+        'Cantrips (at will): mage hand, prestidigitation, ray of frost \n' +
+        ' 1st level (4 slots): detect magic, magic missile, shield, thunderwave \n' +
+        ' 2nd level (3 slots): detect thoughts, invisibility, acid arrow, mirror image \n' +
+        ' 3rd level (3 slots): animate dead, counterspell, dispel magic, fireball \n' +
+        ' 4th level (3 slots): blight, dimension door \n' +
+        ' 5th level (3 slots): cloudkill, scrying \n' +
+        ' 6th level (1 slot): disintegrate, globe of invulnerability \n' +
+        ' 7th level (1 slot): finger of death, plane shift \n' +
+        ' 8th level (1 slot): dominate monster, power word stun \n' +
+        ' 9th level (1 slot): power word kill',
+    },
+    {
+      id: v4(),
+      name: 'Turn Resistance',
+      description:
+        'The lich has advantage on saving throws against any effect that turns undead.',
+    },
+  ],
+  actions: [
+    new MonsterAction({
+      id: v4(),
+      name: 'Paralyzing Touch',
+      isAttack: true,
+      attackType: 'Melee Spell Attack',
+      toHit: '12',
+      reach: '5',
+      damage: '3d6',
+      damageType: 'Cold',
+      description:
+        'The target must succeed on a DC 18 Constitution saving ' +
+        'throw or be paralyzed for 1 minute. The target can repeat the ' +
+        'saving throw at the end of each of its turns, ending the effect on ' +
+        'itself on a success',
+    }),
+  ],
+  legenActions: [
+    new MonsterAction({
+      id: v4(),
+      name: 'Cantrip',
+      isAttack: false,
+      description: 'The lich castrs a cantrip',
+    }),
+    new MonsterAction({
+      id: v4(),
+      name: 'Paralyzing Touch (Costs 2 Actions)',
+      isAttack: false,
+      description: 'The lich uses its Paralyzing Touch.',
+    }),
+    new MonsterAction({
+      id: v4(),
+      name: 'Frightening Gaze (Costs 2 Actions)',
+      isAttack: false,
+      description:
+        'The lich fixes its gaze on one creature it can see ' +
+        'within 10 feet of it. The target must succeed on a DC 18 Wisdom ' +
+        'saving throw against this magic or become frightened for 1 minute. ' +
+        'The frightened target can repeat the saving throw at the end of ' +
+        'each of its turns, ending the effect on itself on a success. ' +
+        "If a target's saving throw is successful or the effect ends for " +
+        "it, the target is immune to the lich's gaze for the next 24 hours.",
+    }),
+    new MonsterAction({
+      id: v4(),
+      name: 'Disrupt Life (Costs 3 Actions)',
+      isAttack: false,
+      description:
+        'Each non-undead creature within 20 feet of the lich ' +
+        'must make a DC 18 Constitution saving throw against this magic, ' +
+        'taking 21 (6d6) necrotic damage on a failed save, or half as much ' +
+        'damage on a successful one.',
+    }),
+  ],
+  reactions: new Array<MonsterAction>(),
+  lairActions: new Array<MonsterAction>(),
+})
+
 export default class MonsterDefinition {
   [key: string]: any;
   name: string = '';
@@ -55,13 +278,13 @@ export default class MonsterDefinition {
     if (init != null) {
       if (init.abilities != null && init.abilities.length > 0) {
         for (let i: number = 0; i < init.abilities.length; i++) {
-          init.abilities[i] = new MonsterAbility(init.abilities[i]);
+          // init.abilities[i] = new MonsterAbility(init.abilities[i]);
         }
       }
 
       if (init.actions != null && init.actions.length > 0) {
         for (let i: number = 0; i < init.actions.length; i++) {
-          init.actions[i] = new MonsterAction(init.actions[i]);
+          // init.actions[i] = new MonsterAction(init.actions[i]);
         }
       }
 

--- a/src/models/MonsterDefinition.tsx
+++ b/src/models/MonsterDefinition.tsx
@@ -11,6 +11,7 @@ import MonsterAction from './MonsterAction';
  * in normal textfields which forces the types to have to be strings
  */
 export type MonsterType = {
+  [key: string]: any;
   name: string;
   size: string;
   type: string;

--- a/src/models/MonsterDefinition.tsx
+++ b/src/models/MonsterDefinition.tsx
@@ -169,138 +169,81 @@ export const exampleMonster = (): MonsterType => ({
         'The lich has advantage on saving throws against any effect that turns undead.',
     },
   ],
-  actions: [],
-  // actions: [
-  //   new MonsterAction({
-  //     id: v4(),
-  //     name: 'Paralyzing Touch',
-  //     isAttack: true,
-  //     attackType: 'Melee Spell Attack',
-  //     toHit: '12',
-  //     reach: '5',
-  //     damage: '3d6',
-  //     damageType: 'Cold',
-  //     description:
-  //       'The target must succeed on a DC 18 Constitution saving ' +
-  //       'throw or be paralyzed for 1 minute. The target can repeat the ' +
-  //       'saving throw at the end of each of its turns, ending the effect on ' +
-  //       'itself on a success',
-  //   }),
-  // ],
-  // legenActions: [
-  //   new MonsterAction({
-  //     id: v4(),
-  //     name: 'Cantrip',
-  //     isAttack: false,
-  //     description: 'The lich castrs a cantrip',
-  //   }),
-  //   new MonsterAction({
-  //     id: v4(),
-  //     name: 'Paralyzing Touch (Costs 2 Actions)',
-  //     isAttack: false,
-  //     description: 'The lich uses its Paralyzing Touch.',
-  //   }),
-  //   new MonsterAction({
-  //     id: v4(),
-  //     name: 'Frightening Gaze (Costs 2 Actions)',
-  //     isAttack: false,
-  //     description:
-  //       'The lich fixes its gaze on one creature it can see ' +
-  //       'within 10 feet of it. The target must succeed on a DC 18 Wisdom ' +
-  //       'saving throw against this magic or become frightened for 1 minute. ' +
-  //       'The frightened target can repeat the saving throw at the end of ' +
-  //       'each of its turns, ending the effect on itself on a success. ' +
-  //       "If a target's saving throw is successful or the effect ends for " +
-  //       "it, the target is immune to the lich's gaze for the next 24 hours.",
-  //   }),
-  //   new MonsterAction({
-  //     id: v4(),
-  //     name: 'Disrupt Life (Costs 3 Actions)',
-  //     isAttack: false,
-  //     description:
-  //       'Each non-undead creature within 20 feet of the lich ' +
-  //       'must make a DC 18 Constitution saving throw against this magic, ' +
-  //       'taking 21 (6d6) necrotic damage on a failed save, or half as much ' +
-  //       'damage on a successful one.',
-  //   }),
-  // ],
+  actions: [
+    {
+      id: v4(),
+      actionType: 'Action',
+      name: 'Paralyzing Touch',
+      isAttack: true,
+      attackType: 'Melee Spell Attack',
+      toHit: '12',
+      reach: '5',
+      damage: '3d6',
+      damageType: 'Cold',
+      description:
+        'The target must succeed on a DC 18 Constitution saving ' +
+        'throw or be paralyzed for 1 minute. The target can repeat the ' +
+        'saving throw at the end of each of its turns, ending the effect on ' +
+        'itself on a success',
+    },
+    {
+      id: v4(),
+      name: 'Cantrip',
+      actionType: 'Legendary',
+      isAttack: false,
+      attackType: '',
+      toHit: '',
+      reach: '',
+      damage: '',
+      damageType: '',
+      description: 'The lich castrs a cantrip',
+    },
+    {
+      id: v4(),
+      name: 'Paralyzing Touch (Costs 2 Actions)',
+      actionType: 'Legendary',
+      isAttack: false,
+      attackType: '',
+      toHit: '',
+      reach: '',
+      damage: '',
+      damageType: '',
+      description: 'The lich uses its Paralyzing Touch.',
+    },
+    {
+      id: v4(),
+      name: 'Frightening Gaze (Costs 2 Actions)',
+      actionType: 'Legendary',
+      isAttack: false,
+      attackType: '',
+      toHit: '',
+      reach: '',
+      damage: '',
+      damageType: '',
+      description:
+        'The lich fixes its gaze on one creature it can see ' +
+        'within 10 feet of it. The target must succeed on a DC 18 Wisdom ' +
+        'saving throw against this magic or become frightened for 1 minute. ' +
+        'The frightened target can repeat the saving throw at the end of ' +
+        'each of its turns, ending the effect on itself on a success. ' +
+        "If a target's saving throw is successful or the effect ends for " +
+        "it, the target is immune to the lich's gaze for the next 24 hours.",
+    },
+    {
+      id: v4(),
+      name: 'Disrupt Life (Costs 3 Actions)',
+      actionType: 'Legendary',
+      isAttack: false,
+      attackType: '',
+      toHit: '',
+      reach: '',
+      damage: '',
+      damageType: '',
+      description:
+        'Each non-undead creature within 20 feet of the lich ' +
+        'must make a DC 18 Constitution saving throw against this magic, ' +
+        'taking 21 (6d6) necrotic damage on a failed save, or half as much ' +
+        'damage on a successful one.',
+    },
+  ],
 })
-
-export default class MonsterDefinition {
-  [key: string]: any;
-  name: string = '';
-  size: string = '';
-  type: string = '';
-  alignment: string = '';
-  armourClass: string = '';
-  hitPoints: string = '';
-  hitDie: string = '';
-  landSpeed: string = '';
-  flySpeed: string = '';
-  burrowSpeed: string = '';
-  climbSpeed: string = '';
-  hoverSpeed: string = '';
-  str: string = '0';
-  dex: string = '0';
-  con: string = '0';
-  int: string = '0';
-  wis: string = '0';
-  chr: string = '0';
-  blindsight: string = '';
-  darkvision: string = '';
-  tremorsense: string = '';
-  truesight: string = '';
-  profBonus: string = '0';
-  challengeRating: string = '';
-  rewardXP: string = '';
-  proficiencies: Array<string> = new Array<string>();
-  savingThrows: Array<string> = new Array<string>();
-  immunities: Array<string> = new Array<string>();
-  condImmunities: Array<string> = new Array<string>();
-  resistances: Array<string> = new Array<string>();
-  weaknesses: Array<string> = new Array<string>();
-  languages: Array<string> = new Array<string>();
-  abilities: Array<MonsterAbility> = new Array<MonsterAbility>();
-  actions: Array<MonsterAction> = new Array<MonsterAction>();
-  legenActions: Array<MonsterAction> = new Array<MonsterAction>();
-  reactions: Array<MonsterAction> = new Array<MonsterAction>();
-  lairActions: Array<MonsterAction> = new Array<MonsterAction>();
-
-  constructor(init?: Partial<MonsterDefinition>) {
-    // If the declaration isn't null, loop through the abilities and
-    // the actions making sure they are clean.
-    // if (init != null) {
-    //   if (init.abilities != null && init.abilities.length > 0) {
-    //     for (let i: number = 0; i < init.abilities.length; i++) {
-    //       // init.abilities[i] = new MonsterAbility(init.abilities[i]);
-    //     }
-    //   }
-
-    //   if (init.actions != null && init.actions.length > 0) {
-    //     for (let i: number = 0; i < init.actions.length; i++) {
-    //       // init.actions[i] = new MonsterAction(init.actions[i]);
-    //     }
-    //   }
-
-    //   if (init.reactions != null && init.reactions.length > 0) {
-    //     for (let i: number = 0; i < init.reactions.length; i++) {
-    //       init.reactions[i] = new MonsterAction(init.reactions[i]);
-    //     }
-    //   }
-
-    //   if (init.legenActions != null && init.legenActions.length > 0) {
-    //     for (let i: number = 0; i < init.legenActions.length; i++) {
-    //       init.legenActions[i] = new MonsterAction(init.legenActions[i]);
-    //     }
-    //   }
-
-    //   if (init.lairActions != null && init.lairActions.length > 0) {
-    //     for (let i: number = 0; i < init.lairActions.length; i++) {
-    //       init.lairActions[i] = new MonsterAction(init.lairActions[i]);
-    //     }
-    //   }
-    // }
-
-    // Object.assign(this, init);
-  }
-}

--- a/src/models/MonsterDefinition.tsx
+++ b/src/models/MonsterDefinition.tsx
@@ -45,9 +45,6 @@ export type MonsterType = {
   languages: Array<string>;
   abilities: Array<MonsterAbility>;
   actions: Array<MonsterAction>;
-  legenActions: Array<MonsterAction>;
-  reactions: Array<MonsterAction>;
-  lairActions: Array<MonsterAction>;
 }
 
 /** Creates an empty monster */
@@ -86,9 +83,6 @@ export const newMonster = (): MonsterType => ({
   languages: new Array<string>(),
   abilities: new Array<MonsterAbility>(),
   actions: new Array<MonsterAction>(),
-  legenActions: new Array<MonsterAction>(),
-  reactions: new Array<MonsterAction>(),
-  lairActions: new Array<MonsterAction>(),
 });
 
 /**
@@ -174,62 +168,61 @@ export const exampleMonster = (): MonsterType => ({
         'The lich has advantage on saving throws against any effect that turns undead.',
     },
   ],
-  actions: [
-    new MonsterAction({
-      id: v4(),
-      name: 'Paralyzing Touch',
-      isAttack: true,
-      attackType: 'Melee Spell Attack',
-      toHit: '12',
-      reach: '5',
-      damage: '3d6',
-      damageType: 'Cold',
-      description:
-        'The target must succeed on a DC 18 Constitution saving ' +
-        'throw or be paralyzed for 1 minute. The target can repeat the ' +
-        'saving throw at the end of each of its turns, ending the effect on ' +
-        'itself on a success',
-    }),
-  ],
-  legenActions: [
-    new MonsterAction({
-      id: v4(),
-      name: 'Cantrip',
-      isAttack: false,
-      description: 'The lich castrs a cantrip',
-    }),
-    new MonsterAction({
-      id: v4(),
-      name: 'Paralyzing Touch (Costs 2 Actions)',
-      isAttack: false,
-      description: 'The lich uses its Paralyzing Touch.',
-    }),
-    new MonsterAction({
-      id: v4(),
-      name: 'Frightening Gaze (Costs 2 Actions)',
-      isAttack: false,
-      description:
-        'The lich fixes its gaze on one creature it can see ' +
-        'within 10 feet of it. The target must succeed on a DC 18 Wisdom ' +
-        'saving throw against this magic or become frightened for 1 minute. ' +
-        'The frightened target can repeat the saving throw at the end of ' +
-        'each of its turns, ending the effect on itself on a success. ' +
-        "If a target's saving throw is successful or the effect ends for " +
-        "it, the target is immune to the lich's gaze for the next 24 hours.",
-    }),
-    new MonsterAction({
-      id: v4(),
-      name: 'Disrupt Life (Costs 3 Actions)',
-      isAttack: false,
-      description:
-        'Each non-undead creature within 20 feet of the lich ' +
-        'must make a DC 18 Constitution saving throw against this magic, ' +
-        'taking 21 (6d6) necrotic damage on a failed save, or half as much ' +
-        'damage on a successful one.',
-    }),
-  ],
-  reactions: new Array<MonsterAction>(),
-  lairActions: new Array<MonsterAction>(),
+  actions: [],
+  // actions: [
+  //   new MonsterAction({
+  //     id: v4(),
+  //     name: 'Paralyzing Touch',
+  //     isAttack: true,
+  //     attackType: 'Melee Spell Attack',
+  //     toHit: '12',
+  //     reach: '5',
+  //     damage: '3d6',
+  //     damageType: 'Cold',
+  //     description:
+  //       'The target must succeed on a DC 18 Constitution saving ' +
+  //       'throw or be paralyzed for 1 minute. The target can repeat the ' +
+  //       'saving throw at the end of each of its turns, ending the effect on ' +
+  //       'itself on a success',
+  //   }),
+  // ],
+  // legenActions: [
+  //   new MonsterAction({
+  //     id: v4(),
+  //     name: 'Cantrip',
+  //     isAttack: false,
+  //     description: 'The lich castrs a cantrip',
+  //   }),
+  //   new MonsterAction({
+  //     id: v4(),
+  //     name: 'Paralyzing Touch (Costs 2 Actions)',
+  //     isAttack: false,
+  //     description: 'The lich uses its Paralyzing Touch.',
+  //   }),
+  //   new MonsterAction({
+  //     id: v4(),
+  //     name: 'Frightening Gaze (Costs 2 Actions)',
+  //     isAttack: false,
+  //     description:
+  //       'The lich fixes its gaze on one creature it can see ' +
+  //       'within 10 feet of it. The target must succeed on a DC 18 Wisdom ' +
+  //       'saving throw against this magic or become frightened for 1 minute. ' +
+  //       'The frightened target can repeat the saving throw at the end of ' +
+  //       'each of its turns, ending the effect on itself on a success. ' +
+  //       "If a target's saving throw is successful or the effect ends for " +
+  //       "it, the target is immune to the lich's gaze for the next 24 hours.",
+  //   }),
+  //   new MonsterAction({
+  //     id: v4(),
+  //     name: 'Disrupt Life (Costs 3 Actions)',
+  //     isAttack: false,
+  //     description:
+  //       'Each non-undead creature within 20 feet of the lich ' +
+  //       'must make a DC 18 Constitution saving throw against this magic, ' +
+  //       'taking 21 (6d6) necrotic damage on a failed save, or half as much ' +
+  //       'damage on a successful one.',
+  //   }),
+  // ],
 })
 
 export default class MonsterDefinition {
@@ -275,38 +268,38 @@ export default class MonsterDefinition {
   constructor(init?: Partial<MonsterDefinition>) {
     // If the declaration isn't null, loop through the abilities and
     // the actions making sure they are clean.
-    if (init != null) {
-      if (init.abilities != null && init.abilities.length > 0) {
-        for (let i: number = 0; i < init.abilities.length; i++) {
-          // init.abilities[i] = new MonsterAbility(init.abilities[i]);
-        }
-      }
+    // if (init != null) {
+    //   if (init.abilities != null && init.abilities.length > 0) {
+    //     for (let i: number = 0; i < init.abilities.length; i++) {
+    //       // init.abilities[i] = new MonsterAbility(init.abilities[i]);
+    //     }
+    //   }
 
-      if (init.actions != null && init.actions.length > 0) {
-        for (let i: number = 0; i < init.actions.length; i++) {
-          // init.actions[i] = new MonsterAction(init.actions[i]);
-        }
-      }
+    //   if (init.actions != null && init.actions.length > 0) {
+    //     for (let i: number = 0; i < init.actions.length; i++) {
+    //       // init.actions[i] = new MonsterAction(init.actions[i]);
+    //     }
+    //   }
 
-      if (init.reactions != null && init.reactions.length > 0) {
-        for (let i: number = 0; i < init.reactions.length; i++) {
-          init.reactions[i] = new MonsterAction(init.reactions[i]);
-        }
-      }
+    //   if (init.reactions != null && init.reactions.length > 0) {
+    //     for (let i: number = 0; i < init.reactions.length; i++) {
+    //       init.reactions[i] = new MonsterAction(init.reactions[i]);
+    //     }
+    //   }
 
-      if (init.legenActions != null && init.legenActions.length > 0) {
-        for (let i: number = 0; i < init.legenActions.length; i++) {
-          init.legenActions[i] = new MonsterAction(init.legenActions[i]);
-        }
-      }
+    //   if (init.legenActions != null && init.legenActions.length > 0) {
+    //     for (let i: number = 0; i < init.legenActions.length; i++) {
+    //       init.legenActions[i] = new MonsterAction(init.legenActions[i]);
+    //     }
+    //   }
 
-      if (init.lairActions != null && init.lairActions.length > 0) {
-        for (let i: number = 0; i < init.lairActions.length; i++) {
-          init.lairActions[i] = new MonsterAction(init.lairActions[i]);
-        }
-      }
-    }
+    //   if (init.lairActions != null && init.lairActions.length > 0) {
+    //     for (let i: number = 0; i < init.lairActions.length; i++) {
+    //       init.lairActions[i] = new MonsterAction(init.lairActions[i]);
+    //     }
+    //   }
+    // }
 
-    Object.assign(this, init);
+    // Object.assign(this, init);
   }
 }

--- a/src/reducers/monsterReducer.tsx
+++ b/src/reducers/monsterReducer.tsx
@@ -25,7 +25,10 @@ export default createSlice({
     },
     /** Updates the passed in ability */
     updateAbility(state, action: PayloadAction<MonsterAbility>) {
+      const updateIndex: number = state.abilities.findIndex(
+        (ability: MonsterAbility) => ability.id === action.payload.id);
 
+      state.abilities[updateIndex] = action.payload;
     },
     /** Adds the action to the state of normal actions */
     addAction(state, payload: PayloadAction<MonsterAction>) {

--- a/src/reducers/monsterReducer.tsx
+++ b/src/reducers/monsterReducer.tsx
@@ -13,6 +13,9 @@ export default createSlice({
     /** Resets the monster to the initial state */
     reset: () => initialState,
     loadExample: () => exampleMonster(),
+    setMonsterFromObject(state, action: PayloadAction<MonsterType>) {
+      state = action.payload;
+    },
     updateProperty(state, action: PayloadAction<{property: string, value: string | boolean}>) {
       state[action.payload.property] = action.payload.value;
     },

--- a/src/reducers/monsterReducer.tsx
+++ b/src/reducers/monsterReducer.tsx
@@ -13,6 +13,16 @@ export default createSlice({
     /** Resets the monster to the initial state */
     reset: () => initialState,
     loadExample: () => exampleMonster(),
+    updateProperty(state, action: PayloadAction<{property: string, value: string | boolean}>) {
+      state[action.payload.property] = action.payload.value;
+    },
+    addToCollection(state, action: PayloadAction<{property: string, value: string}>) {
+      state[action.payload.property].push(action.payload.value);
+    },
+    removeFromCollection(state, action: PayloadAction<{property: string, value: string}>) {
+      const {property, value} = action.payload;
+      state[property] = state[property].filter((item: string) => item !== value);
+    },
     /** 
      * Adds the action to the state of normal actions
      * @param action the payload of the monster ability to add

--- a/src/reducers/monsterReducer.tsx
+++ b/src/reducers/monsterReducer.tsx
@@ -13,7 +13,11 @@ export default createSlice({
     /** Resets the monster to the initial state */
     reset: () => initialState,
     loadExample: () => exampleMonster(),
-    /** Adds the action to the state of normal actions */
+    /** 
+     * Adds the action to the state of normal actions
+     * @param state the state of the monster
+     * @param action the payload of the monster ability to add
+     */
     addAbility(state, action: PayloadAction<MonsterAbility>) {
       const {name, description} = action.payload;
       state.abilities.push({
@@ -23,31 +27,53 @@ export default createSlice({
       });
       return;
     },
-    /** Updates the passed in ability */
+    /** 
+     * Updates the passed in ability
+     * @param state the state of the monster
+     * @param action the payload of the monster ability to update
+     */
     updateAbility(state, action: PayloadAction<MonsterAbility>) {
       const updateIndex: number = state.abilities.findIndex(
         (ability: MonsterAbility) => ability.id === action.payload.id);
 
       state.abilities[updateIndex] = action.payload;
+
+      return;
+    },
+    /**
+     * Removes the ability using the passed in id
+     * @param state the state of the monster
+     * @param action the payload of the id of the ability to remove
+     */
+    removeAbility(state, action: PayloadAction<string>) {
+      state.abilities = state.abilities.filter(
+        (ability: MonsterAbility) => ability.id !== action.payload);
+      
+      return;
     },
     /** Adds the action to the state of normal actions */
-    addAction(state, payload: PayloadAction<MonsterAction>) {
+    addAction(state, action: PayloadAction<MonsterAction>) {
       // state.monster.actions.push(payload.payload);
+      state.actions.push({
+        ...action.payload,
+        id: v4(),
+      })
       return;
     },
-    /** Adds the action to the state of legendary actions */
-    addLegenAction(state, payload: PayloadAction<MonsterAction>) {
-      // state.monster.legenActions.push(payload.payload);
+    /** Updates an action using the incoming action */
+    updateAction(state, action: PayloadAction<MonsterAction>) {
+      const updateIndex: number = state.actions.findIndex(
+        (monsterAction: MonsterAction) => monsterAction.id === action.payload.id);
+
+      state.actions[updateIndex] = action.payload;
+
       return;
     },
-    /** Add the action to the state of reactions */
-    addReaction(state, payload: PayloadAction<MonsterAction>) {
-      // state.monster.reactions.push(payload.payload);
-      return;
-    },
-    /** Adds the action to the state of lair actions */
-    addLairAction(state, payload: PayloadAction<MonsterAction>) {
-      // state.monster.lairActions.push(payload.payload);
+    /** Removes the action from the list of actions */
+    removeAction(state, action: PayloadAction<string>) {
+      state.actions = state.actions.filter(
+        (monsterAction: MonsterAction) => monsterAction.id !== action.payload);
+      
       return;
     },
   }

--- a/src/reducers/monsterReducer.tsx
+++ b/src/reducers/monsterReducer.tsx
@@ -15,7 +15,6 @@ export default createSlice({
     loadExample: () => exampleMonster(),
     /** 
      * Adds the action to the state of normal actions
-     * @param state the state of the monster
      * @param action the payload of the monster ability to add
      */
     addAbility(state, action: PayloadAction<MonsterAbility>) {
@@ -29,7 +28,6 @@ export default createSlice({
     },
     /** 
      * Updates the passed in ability
-     * @param state the state of the monster
      * @param action the payload of the monster ability to update
      */
     updateAbility(state, action: PayloadAction<MonsterAbility>) {
@@ -42,7 +40,6 @@ export default createSlice({
     },
     /**
      * Removes the ability using the passed in id
-     * @param state the state of the monster
      * @param action the payload of the id of the ability to remove
      */
     removeAbility(state, action: PayloadAction<string>) {
@@ -51,7 +48,10 @@ export default createSlice({
       
       return;
     },
-    /** Adds the action to the state of normal actions */
+    /** 
+     * Adds the action to the state of normal actions 
+     * @param action the payload of the monster action we're adding
+     */
     addAction(state, action: PayloadAction<MonsterAction>) {
       // state.monster.actions.push(payload.payload);
       state.actions.push({
@@ -60,7 +60,10 @@ export default createSlice({
       })
       return;
     },
-    /** Updates an action using the incoming action */
+    /**
+     * Updates an action using the incoming action
+     * @param action the payload of the action we're updating
+     */
     updateAction(state, action: PayloadAction<MonsterAction>) {
       const updateIndex: number = state.actions.findIndex(
         (monsterAction: MonsterAction) => monsterAction.id === action.payload.id);
@@ -69,7 +72,10 @@ export default createSlice({
 
       return;
     },
-    /** Removes the action from the list of actions */
+    /**
+     * Removes the action from the list of actions 
+     * @param action the id string of the action to remove
+     */
     removeAction(state, action: PayloadAction<string>) {
       state.actions = state.actions.filter(
         (monsterAction: MonsterAction) => monsterAction.id !== action.payload);

--- a/src/reducers/monsterReducer.tsx
+++ b/src/reducers/monsterReducer.tsx
@@ -1,0 +1,51 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { v4 } from 'uuid';
+import MonsterAbility from '../models/MonsterAbility';
+import MonsterAction from '../models/MonsterAction';
+import { exampleMonster, MonsterType, newMonster } from '../models/MonsterDefinition';
+
+const initialState: MonsterType = newMonster();
+
+export default createSlice({
+  initialState,
+  name: 'monster',
+  reducers: {
+    /** Resets the monster to the initial state */
+    reset: () => initialState,
+    loadExample: () => exampleMonster(),
+    /** Adds the action to the state of normal actions */
+    addAbility(state, action: PayloadAction<MonsterAbility>) {
+      const {name, description} = action.payload;
+      state.abilities.push({
+        id: v4(),
+        name: name,
+        description: description
+      });
+      return;
+    },
+    /** Updates the passed in ability */
+    updateAbility(state, action: PayloadAction<MonsterAbility>) {
+
+    },
+    /** Adds the action to the state of normal actions */
+    addAction(state, payload: PayloadAction<MonsterAction>) {
+      // state.monster.actions.push(payload.payload);
+      return;
+    },
+    /** Adds the action to the state of legendary actions */
+    addLegenAction(state, payload: PayloadAction<MonsterAction>) {
+      // state.monster.legenActions.push(payload.payload);
+      return;
+    },
+    /** Add the action to the state of reactions */
+    addReaction(state, payload: PayloadAction<MonsterAction>) {
+      // state.monster.reactions.push(payload.payload);
+      return;
+    },
+    /** Adds the action to the state of lair actions */
+    addLairAction(state, payload: PayloadAction<MonsterAction>) {
+      // state.monster.lairActions.push(payload.payload);
+      return;
+    },
+  }
+});

--- a/src/selectors/monsterSelector.tsx
+++ b/src/selectors/monsterSelector.tsx
@@ -1,3 +1,4 @@
+import MonsterAction from "../models/MonsterAction";
 import { AppState } from "../store/store";
 
 export const monsterSelector = (state: AppState) => state;
@@ -13,7 +14,8 @@ export const monsterSelector = (state: AppState) => state;
 export const abilitiesSelector = (state: AppState) => state.abilities;
 
 // // Select all the actions
-// export const actionsSelector = (state: AppState) => state.monster.actions;
-// export const legenActionsSelector = (state: AppState) => state.monster.legenActions;
-// export const reactionsSelector = (state: AppState) => state.monster.reactions;
-// export const lairActionsSelector = (state: AppState) => state.monster.lairActions;
+export const actionsSelector = (state: AppState) => state.actions;
+export const normActionsSelector = (state: AppState) => state.actions.filter((action: MonsterAction) => action.actionType === 'Action');
+export const legenActionsSelector = (state: AppState) => state.actions.filter((action: MonsterAction) => action.actionType === 'Legendary')
+export const reactionsSelector = (state: AppState) => state.actions.filter((action: MonsterAction) => action.actionType === 'Reaction')
+export const lairActionsSelector = (state: AppState) => state.actions.filter((action: MonsterAction) => action.actionType === 'Lair')

--- a/src/selectors/monsterSelector.tsx
+++ b/src/selectors/monsterSelector.tsx
@@ -1,0 +1,19 @@
+import { AppState } from "../store/store";
+
+export const monsterSelector = (state: AppState) => state;
+
+// export const profsSelectorSelector = (state: AppState) => state.monster.proficiencies;
+// export const savingThrowsSelector = (state: AppState) => state.monster.savingThrows;
+// export const immunitiesSelector = (state: AppState) => state.monster.immunities;
+// export const condImmunitiesSelector = (state: AppState) => state.monster.condImmunities;
+// export const resistancesSelector = (state: AppState) => state.monster.resistances;
+// export const weaknessesSelector = (state: AppState) => state.monster.weaknesses;
+// export const languagesSelector = (state: AppState) => state.monster.languages;
+
+export const abilitiesSelector = (state: AppState) => state.abilities;
+
+// // Select all the actions
+// export const actionsSelector = (state: AppState) => state.monster.actions;
+// export const legenActionsSelector = (state: AppState) => state.monster.legenActions;
+// export const reactionsSelector = (state: AppState) => state.monster.reactions;
+// export const lairActionsSelector = (state: AppState) => state.monster.lairActions;

--- a/src/store/store.tsx
+++ b/src/store/store.tsx
@@ -1,0 +1,9 @@
+import { configureStore } from "@reduxjs/toolkit";
+import monsterSlice from '../reducers/monsterReducer';
+
+export const makeStore = () => 
+  configureStore({
+    reducer: monsterSlice.reducer,
+  });
+
+export type AppState = ReturnType<typeof monsterSlice.reducer>;


### PR DESCRIPTION
**Props**
- Prop-types no longer get used. It now grabs the prop types from a defined prop "type" that is declared in the component file
- Restructured props to use more redux state management styles

**Types**
- Moved a bunch of types from classes to types

**Redux**
- Added react-redux and redux-toolkit
- Moved all state and state management to use the redux
